### PR TITLE
Add 2026-05 External Access to UC Managed Delta Tables blog companion

### DIFF
--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/.env.example
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/.env.example
@@ -1,0 +1,73 @@
+# Copy this file to `.env` and fill in the values. `_common.py` loads
+# `.env` automatically when the scripts run. `.env` is gitignored — never
+# commit it.
+
+# --- Workspace + UC coordinates ---------------------------------------------
+# Databricks workspace URL — no trailing slash.
+DATABRICKS_HOST="https://<your-workspace>.cloud.databricks.com"
+
+# Override only if you picked different names in 00_setup_databricks.sql.
+UC_CATALOG="uc_ext_access_demo"
+UC_SCHEMA="tpch_managed"
+
+# AWS region of the S3 bucket that backs the UC metastore.
+AWS_REGION="<your-region>"   # e.g. us-west-2
+
+# --- Service principal credentials ------------------------------------------
+# The External Access Beta is built for production pipelines, so these
+# scripts authenticate with machine-to-machine OAuth against a Databricks
+# *service principal* — no PATs.
+#
+# How to create the service principal + secret (AWS Databricks):
+#   1. Workspace admin console > Identity and access > Service principals >
+#      Add service principal. Save the application_id (client_id).
+#   2. Open the SP, go to OAuth secrets > Generate secret. Copy the
+#      client_secret (shown once).
+#   3. Grant the SP the privileges in 00_setup_databricks.sql, including
+#      EXTERNAL_USE_SCHEMA on uc_ext_access_demo.tpch_managed.
+#
+# Pick ONE of the two credential resolution paths below.
+
+# --- Path A (preferred): resolve from a Databricks secret scope -------------
+# `_common.py` uses your local Databricks CLI profile to fetch the SP
+# credentials from a Databricks secret scope at runtime, so the raw values
+# never land on disk. Run `databricks auth login --profile <name>` once to
+# set the profile up.
+DATABRICKS_PROFILE="<your-cli-profile>"
+SP_SECRET_SCOPE="<your-secret-scope>"
+SP_CLIENT_ID_SECRET_KEY="<key-holding-sp-client-id>"
+SP_CLIENT_SECRET_SECRET_KEY="<key-holding-sp-client-secret>"
+
+# --- Path B (fallback): paste the raw OAuth values --------------------------
+# Use this if you don't have a Databricks CLI profile locally. If both
+# paths are set, the direct values win.
+# DATABRICKS_CLIENT_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+# DATABRICKS_CLIENT_SECRET="dosexxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# --- Setup runner inputs ----------------------------------------------------
+# Used by run_setup.py (executes 00_setup_databricks.sql via the SQL
+# Statement Execution API using DATABRICKS_PROFILE auth, not the SP).
+# Get the warehouse id from the Databricks UI or
+# `databricks warehouses list --profile <profile>`.
+DATABRICKS_WAREHOUSE_ID="<your-serverless-warehouse-id>"
+
+# DEMO_PRINCIPAL is the application_id of the service principal that
+# receives USE CATALOG / USE SCHEMA / SELECT / MODIFY / CREATE TABLE /
+# EXTERNAL_USE_SCHEMA grants. Defaults to the SP we authenticate as
+# (the same client_id resolved from SP_SECRET_SCOPE above), so leave
+# this unset for the common case. Set it only if grants should land
+# on a *different* principal than the one holding the OAuth credentials.
+# DEMO_PRINCIPAL="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# --- Optional Spark package resolution --------------------------------------
+# Override Spark artifact versions (passed to --packages in build_spark).
+# Defaults track the latest published releases — bump only when needed.
+# SCALA_VERSION="2.13"
+# DELTA_SPARK_VERSION="4.2.0"
+# UC_SPARK_VERSION="0.4.1"
+# HADOOP_AWS_VERSION="3.4.2"
+# EXTRA_SPARK_PACKAGES="org.apache.hadoop:hadoop-azure:3.4.2"
+
+# Point Spark's Ivy resolver at a specific mirror (comma-separated).
+# Useful when repo1.maven.org is blocked at the network layer.
+# SPARK_REPOSITORIES="https://maven-central.storage.googleapis.com/maven2"

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/00_setup_databricks.sql
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/00_setup_databricks.sql
@@ -1,0 +1,86 @@
+-- ============================================================================
+-- 00_setup_databricks.sql
+-- Run this inside Databricks (SQL editor, notebook, or DBSQL warehouse)
+-- using a workspace admin or a principal with CREATE CATALOG privileges.
+--
+-- What this does:
+--   1. Creates a catalog and schema for the External Access Beta demo.
+--   2. Clones the 8 tables from samples.tpch into that schema as UC
+--      managed Delta tables (CREATE TABLE AS SELECT).
+--   3. Enables external data access on the metastore.
+--   4. Grants EXTERNAL_USE_SCHEMA so external engines can operate on the
+--      managed tables.
+--
+-- Replace the placeholders before running:
+--   <DEMO_PRINCIPAL>  the *service principal* you created for M2M OAuth.
+--                    Use the SP's application (client) id, e.g.
+--                    'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'.
+--                    Create it ahead of time under Workspace admin >
+--                    Identity and access > Service principals, then
+--                    generate an OAuth secret for it. These credentials
+--                    flow into scripts/.env (see .env.example).
+-- ============================================================================
+
+-- 0. Clean slate --------------------------------------------------------------
+-- Drop the demo catalog (and everything inside it) so every run starts from
+-- a known-empty state. Tables created by the downstream demo scripts
+-- (orders_summary, orders_stream, customer_nation_join, ...) are removed
+-- along with the catalog. No-op on the first run.
+DROP CATALOG IF EXISTS uc_ext_access_demo CASCADE;
+
+-- 1. Catalog + schema ---------------------------------------------------------
+CREATE CATALOG uc_ext_access_demo
+  COMMENT 'Demo catalog for External Access to UC Managed Delta Tables (Beta)';
+
+CREATE SCHEMA uc_ext_access_demo.tpch_managed
+  COMMENT 'Managed Delta clones of samples.tpch for external-engine demos';
+
+USE CATALOG uc_ext_access_demo;
+USE SCHEMA tpch_managed;
+
+-- 2. Clone samples.tpch as managed Delta tables -------------------------------
+-- CTAS into the managed schema produces UC managed Delta tables by default.
+
+CREATE OR REPLACE TABLE customer AS SELECT * FROM samples.tpch.customer;
+CREATE OR REPLACE TABLE lineitem AS SELECT * FROM samples.tpch.lineitem;
+CREATE OR REPLACE TABLE nation   AS SELECT * FROM samples.tpch.nation;
+CREATE OR REPLACE TABLE orders   AS SELECT * FROM samples.tpch.orders;
+CREATE OR REPLACE TABLE part     AS SELECT * FROM samples.tpch.part;
+CREATE OR REPLACE TABLE partsupp AS SELECT * FROM samples.tpch.partsupp;
+CREATE OR REPLACE TABLE region   AS SELECT * FROM samples.tpch.region;
+CREATE OR REPLACE TABLE supplier AS SELECT * FROM samples.tpch.supplier;
+
+-- Sanity check
+SELECT 'customer' AS table_name, count(*) AS row_count FROM customer
+UNION ALL SELECT 'lineitem', count(*) FROM lineitem
+UNION ALL SELECT 'nation',   count(*) FROM nation
+UNION ALL SELECT 'orders',   count(*) FROM orders
+UNION ALL SELECT 'part',     count(*) FROM part
+UNION ALL SELECT 'partsupp', count(*) FROM partsupp
+UNION ALL SELECT 'region',   count(*) FROM region
+UNION ALL SELECT 'supplier', count(*) FROM supplier;
+
+-- 3. Grants for external access ----------------------------------------------
+-- External Data Access must be enabled on the metastore. Do this once per
+-- metastore in the admin console or via REST API. SQL form below (DBR 18.0+):
+--   ALTER METASTORE SET external_data_access = true;
+--
+-- EXTERNAL_USE_SCHEMA is the grant that opens up external engines to operate
+-- on the tables in this schema.
+
+GRANT USE CATALOG ON CATALOG uc_ext_access_demo TO `<DEMO_PRINCIPAL>`;
+GRANT USE SCHEMA  ON SCHEMA  uc_ext_access_demo.tpch_managed TO `<DEMO_PRINCIPAL>`;
+GRANT SELECT      ON SCHEMA  uc_ext_access_demo.tpch_managed TO `<DEMO_PRINCIPAL>`;
+GRANT MODIFY      ON SCHEMA  uc_ext_access_demo.tpch_managed TO `<DEMO_PRINCIPAL>`;
+GRANT CREATE TABLE ON SCHEMA uc_ext_access_demo.tpch_managed TO `<DEMO_PRINCIPAL>`;
+GRANT EXTERNAL_USE_SCHEMA ON SCHEMA uc_ext_access_demo.tpch_managed TO `<DEMO_PRINCIPAL>`;
+
+-- 4. Show table properties so you can confirm they are managed Delta ----------
+DESCRIBE EXTENDED orders;
+
+-- Next steps:
+--   * Confirm the workspace is enrolled in the "External Access to Unity
+--     Catalog Managed Delta Table" preview (Settings > Previews).
+--   * Put your workspace host, the SP's client_id, and its OAuth secret
+--     into scripts/.env (see .env.example).
+--   * Run scripts/01_spark_external_read.py from a local machine.

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/01_spark_external_read.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/01_spark_external_read.py
@@ -9,7 +9,7 @@ Demonstrates:
   * SELECT from `orders`
   * DESCRIBE HISTORY of `orders` — every commit will be attributed to UC
 """
-from _common import UC_CATALOG, UC_SCHEMA, build_spark, fq, print_banner
+from _common import UC_CATALOG, UC_SCHEMA, build_spark, fq, print_banner, script_banner
 
 
 def main() -> None:
@@ -27,7 +27,9 @@ def main() -> None:
         print(f"  {t:<10s} {n:>12,d}")
 
     print_banner("DESCRIBE HISTORY orders")
-    spark.sql(f"DESCRIBE HISTORY {fq('orders')}").show(10, truncate=False)
+    spark.sql(f"DESCRIBE HISTORY {fq('orders')}").select(
+        "version", "timestamp", "operation", "engineInfo"
+    ).orderBy("version").show(20, truncate=False)
 
     # ---- Time travel ------------------------------------------------------
     # Delta SQL `VERSION AS OF N` reads the table as of commit version N.
@@ -47,4 +49,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    with script_banner(__file__):
+        main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/01_spark_external_read.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/01_spark_external_read.py
@@ -1,0 +1,36 @@
+"""Read UC managed Delta tables from an *external* Delta Spark session.
+
+Run this on a local machine with Python 3.11+ and Java 17+ installed. The
+session picks up Delta Spark 4.2 + Unity Catalog 0.4.1 via --packages and
+points at the Databricks workspace configured in scripts/.env.
+
+Demonstrates:
+  * Listing the TPCH tables cloned by 00_setup_databricks.sql
+  * SELECT from `orders`
+  * DESCRIBE HISTORY of `orders` — every commit will be attributed to UC
+"""
+from _common import UC_CATALOG, UC_SCHEMA, build_spark, fq, print_banner
+
+
+def main() -> None:
+    spark = build_spark("01_spark_external_read")
+
+    print_banner(f"Tables in {UC_CATALOG}.{UC_SCHEMA}")
+    spark.sql(f"SHOW TABLES IN {UC_CATALOG}.{UC_SCHEMA}").show(truncate=False)
+
+    print_banner("Sample rows from orders")
+    spark.table(fq("orders")).show(5, truncate=False)
+
+    print_banner("Row counts across TPCH clones")
+    for t in ("customer", "lineitem", "nation", "orders", "part", "partsupp", "region", "supplier"):
+        n = spark.table(fq(t)).count()
+        print(f"  {t:<10s} {n:>12,d}")
+
+    print_banner("DESCRIBE HISTORY orders")
+    spark.sql(f"DESCRIBE HISTORY {fq('orders')}").show(10, truncate=False)
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/01_spark_external_read.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/01_spark_external_read.py
@@ -29,6 +29,20 @@ def main() -> None:
     print_banner("DESCRIBE HISTORY orders")
     spark.sql(f"DESCRIBE HISTORY {fq('orders')}").show(10, truncate=False)
 
+    # ---- Time travel ------------------------------------------------------
+    # Delta SQL `VERSION AS OF N` reads the table as of commit version N.
+    # Version 0 is the original CTAS that seeded the table; the current
+    # state reflects every commit (Databricks-Runtime + external engines)
+    # since then.
+    print_banner(f"Time travel: {fq('orders')} VERSION AS OF 0 vs latest")
+    v0 = spark.sql(
+        f"SELECT count(*) AS n FROM {fq('orders')} VERSION AS OF 0"
+    ).first()["n"]
+    now = spark.table(fq("orders")).count()
+    print(f"  rows at version 0:   {v0:>12,d}")
+    print(f"  rows now (latest):   {now:>12,d}")
+    print(f"  delta (post-v0):     {now - v0:>+12,d}")
+
     spark.stop()
 
 

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/02_spark_external_write.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/02_spark_external_write.py
@@ -11,7 +11,7 @@ coordinated across engines.
 """
 from pyspark.sql import Row
 
-from _common import build_spark, fq, print_banner
+from _common import build_spark, fq, print_banner, script_banner
 
 
 NEW_ORDER_ROWS = [
@@ -98,14 +98,19 @@ def main() -> None:
 
     spark.table(fq("orders_summary")).show(truncate=False)
 
-    print_banner("DESCRIBE HISTORY orders (shows the append commit)")
-    spark.sql(f"DESCRIBE HISTORY {fq('orders')}").show(5, truncate=False)
+    print_banner("DESCRIBE HISTORY orders (shows the DELETE + APPEND commits)")
+    spark.sql(f"DESCRIBE HISTORY {fq('orders')}").select(
+        "version", "timestamp", "operation", "engineInfo"
+    ).orderBy("version").show(20, truncate=False)
 
     print_banner("DESCRIBE HISTORY orders_summary (shows the CTAS commit)")
-    spark.sql(f"DESCRIBE HISTORY {fq('orders_summary')}").show(5, truncate=False)
+    spark.sql(f"DESCRIBE HISTORY {fq('orders_summary')}").select(
+        "version", "timestamp", "operation", "engineInfo"
+    ).orderBy("version").show(10, truncate=False)
 
     spark.stop()
 
 
 if __name__ == "__main__":
-    main()
+    with script_banner(__file__):
+        main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/02_spark_external_write.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/02_spark_external_write.py
@@ -1,0 +1,111 @@
+"""Write to UC managed Delta tables from an *external* Delta Spark session.
+
+Demonstrates two operations that were not possible before the External
+Access Beta:
+  1. Batch APPEND into an existing managed Delta table (orders).
+  2. CREATE TABLE AS SELECT — producing a brand-new managed Delta table
+     (orders_summary) directly from an external engine.
+
+Every write flows through UC catalog commits: the transaction log stays
+coordinated across engines.
+"""
+from pyspark.sql import Row
+
+from _common import build_spark, fq, print_banner
+
+
+NEW_ORDER_ROWS = [
+    Row(
+        o_orderkey=9_000_000_001,
+        o_custkey=1,
+        o_orderstatus="O",
+        o_totalprice=123.45,
+        o_orderdate="2026-04-23",
+        o_orderpriority="3-MEDIUM",
+        o_clerk="Clerk#external-spark",
+        o_shippriority=0,
+        o_comment="inserted by external Delta Spark via catalog commits",
+    ),
+    Row(
+        o_orderkey=9_000_000_002,
+        o_custkey=2,
+        o_orderstatus="O",
+        o_totalprice=678.90,
+        o_orderdate="2026-04-23",
+        o_orderpriority="5-LOW",
+        o_clerk="Clerk#external-spark",
+        o_shippriority=0,
+        o_comment="inserted by external Delta Spark via catalog commits",
+    ),
+]
+
+
+MARKER_CLERK = "Clerk#external-spark"
+
+
+def main() -> None:
+    spark = build_spark("02_spark_external_write")
+
+    # ---- 0. Idempotency — remove any rows left by a prior run ---------------
+    # The marker clerk uniquely identifies rows this script inserted, so
+    # repeat runs converge on the same end state (2 added rows total).
+    print_banner(f"Deleting prior {MARKER_CLERK!r} rows from orders (idempotency)")
+    spark.sql(
+        f"DELETE FROM {fq('orders')} WHERE o_clerk = '{MARKER_CLERK}'"
+    )
+
+    # ---- 1. Append rows to the existing managed Delta table ----------------
+    print_banner("Appending 2 rows to orders from external Spark")
+    orders = spark.table(fq("orders"))
+    # Cast the new rows to the target schema so append is type-safe
+    new_df = spark.createDataFrame(NEW_ORDER_ROWS).selectExpr(
+        "cast(o_orderkey as bigint)",
+        "cast(o_custkey as bigint)",
+        "cast(o_orderstatus as string)",
+        "cast(o_totalprice as decimal(18,2))",
+        "cast(o_orderdate as date)",
+        "cast(o_orderpriority as string)",
+        "cast(o_clerk as string)",
+        "cast(o_shippriority as int)",
+        "cast(o_comment as string)",
+    )
+    new_df.write.mode("append").saveAsTable(fq("orders"))
+
+    print("New row count for orders:", spark.table(fq("orders")).count())
+
+    # ---- 2. CREATE TABLE AS SELECT from external Spark ---------------------
+    print_banner("CTAS: orders_summary (managed Delta) from external Spark")
+    spark.sql(f"DROP TABLE IF EXISTS {fq('orders_summary')}")
+    # USING DELTA is required for CREATE TABLE via UCSingleCatalog (external
+    # Spark does not default to Delta). The catalogManaged table feature is
+    # what routes commits through UC rather than the filesystem log.
+    spark.sql(
+        f"""
+        CREATE TABLE {fq('orders_summary')}
+        USING DELTA
+        TBLPROPERTIES ('delta.feature.catalogManaged' = 'supported')
+        AS
+        SELECT
+          o_orderstatus,
+          o_orderpriority,
+          count(*)              AS order_count,
+          sum(o_totalprice)     AS total_value,
+          avg(o_totalprice)     AS avg_value
+        FROM {fq('orders')}
+        GROUP BY o_orderstatus, o_orderpriority
+        """
+    )
+
+    spark.table(fq("orders_summary")).show(truncate=False)
+
+    print_banner("DESCRIBE HISTORY orders (shows the append commit)")
+    spark.sql(f"DESCRIBE HISTORY {fq('orders')}").show(5, truncate=False)
+
+    print_banner("DESCRIBE HISTORY orders_summary (shows the CTAS commit)")
+    spark.sql(f"DESCRIBE HISTORY {fq('orders_summary')}").show(5, truncate=False)
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/03_spark_streaming.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/03_spark_streaming.py
@@ -29,7 +29,7 @@ ROWS_PER_SECOND = int(os.environ.get("STREAM_ROWS_PER_SECOND", "50"))
 
 
 def main() -> None:
-    spark = build_spark("09_spark_streaming_external_write")
+    spark = build_spark("03_spark_streaming")
 
     # Idempotency: drop and recreate so each run produces a reproducible
     # row count / commit sequence. The table is still the same managed

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/03_spark_streaming.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/03_spark_streaming.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from pyspark.sql.functions import col, concat, current_date, lit, expr
 
-from _common import build_spark, fq, print_banner
+from _common import build_spark, fq, print_banner, script_banner
 
 
 STREAM_TABLE = "orders_stream"
@@ -142,4 +142,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    with script_banner(__file__):
+        main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/03_spark_streaming.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/03_spark_streaming.py
@@ -1,0 +1,132 @@
+"""Spark Structured Streaming into a UC managed Delta table from outside Databricks.
+
+Demonstrates that catalog commits work for streaming writes too, not just
+batch. A rate-source stream (no external broker required) is projected
+into an orders-shaped schema and appended to `orders_stream` — a UC
+managed Delta table created at the start of the run.
+
+The stream runs for STREAM_DURATION_SECONDS (default 30s), checkpoints
+locally, then stops cleanly so DESCRIBE HISTORY shows a finite number of
+micro-batch commits. Idempotent: drops + recreates the target table at
+the start, so re-runs converge on the same row count and version
+sequence.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from pyspark.sql.functions import col, concat, current_date, lit, expr
+
+from _common import build_spark, fq, print_banner
+
+
+STREAM_TABLE = "orders_stream"
+STREAM_DURATION_SECONDS = int(os.environ.get("STREAM_DURATION_SECONDS", "30"))
+ROWS_PER_SECOND = int(os.environ.get("STREAM_ROWS_PER_SECOND", "50"))
+
+
+def main() -> None:
+    spark = build_spark("09_spark_streaming_external_write")
+
+    # Idempotency: drop and recreate so each run produces a reproducible
+    # row count / commit sequence. The table is still the same managed
+    # Delta table whose commits are coordinated by UC.
+    print_banner(f"Drop + create {fq(STREAM_TABLE)} (managed Delta, clean slate)")
+    spark.sql(f"DROP TABLE IF EXISTS {fq(STREAM_TABLE)}")
+    spark.sql(
+        f"""
+        CREATE TABLE {fq(STREAM_TABLE)} (
+            o_orderkey       BIGINT,
+            o_custkey        BIGINT,
+            o_orderstatus    STRING,
+            o_totalprice     DECIMAL(18,2),
+            o_orderdate      DATE,
+            o_orderpriority  STRING,
+            o_clerk          STRING,
+            o_shippriority   INT,
+            o_comment        STRING
+        )
+        USING DELTA
+        TBLPROPERTIES ('delta.feature.catalogManaged' = 'supported')
+        """
+    )
+
+    # Local checkpoint — the External Access Beta doesn't require the
+    # checkpoint to live in cloud storage; UC only coordinates the
+    # transaction log commit, not micro-batch state.
+    ckpt_dir = Path(tempfile.mkdtemp(prefix="uc_ext_stream_ckpt_"))
+    print(f"Checkpoint: {ckpt_dir}")
+
+    # Synthetic source: rate generator → orders-shaped row. Keeps the
+    # demo self-contained (no Kafka / Kinesis / files required).
+    src = (
+        spark.readStream.format("rate")
+        .option("rowsPerSecond", ROWS_PER_SECOND)
+        .load()
+    )
+
+    shaped = (
+        src
+        .withColumn("o_orderkey", (lit(9_100_000_000) + col("value")).cast("bigint"))
+        .withColumn("o_custkey", ((col("value") % lit(1500)) + lit(1)).cast("bigint"))
+        .withColumn("o_orderstatus", lit("O"))
+        .withColumn("o_totalprice", expr("cast(rand() * 1000 as decimal(18,2))"))
+        .withColumn("o_orderdate", current_date())
+        .withColumn("o_orderpriority", lit("3-MEDIUM"))
+        .withColumn("o_clerk", lit("Clerk#external-spark-stream"))
+        .withColumn("o_shippriority", lit(0))
+        .withColumn(
+            "o_comment",
+            concat(lit("streamed by external Spark @ batch_value="), col("value").cast("string")),
+        )
+        .select(
+            "o_orderkey",
+            "o_custkey",
+            "o_orderstatus",
+            "o_totalprice",
+            "o_orderdate",
+            "o_orderpriority",
+            "o_clerk",
+            "o_shippriority",
+            "o_comment",
+        )
+    )
+
+    print_banner(
+        f"Start streaming append to {fq(STREAM_TABLE)} for ~{STREAM_DURATION_SECONDS}s"
+    )
+    query = (
+        shaped.writeStream
+        .format("delta")
+        .outputMode("append")
+        .option("checkpointLocation", str(ckpt_dir))
+        .trigger(processingTime="5 seconds")
+        .toTable(fq(STREAM_TABLE))
+    )
+
+    try:
+        # awaitTermination(timeout) returns when the stream stops or the
+        # timeout elapses — whichever comes first.
+        query.awaitTermination(STREAM_DURATION_SECONDS)
+    finally:
+        if query.isActive:
+            query.stop()
+        # Give the driver a moment to finalise the last micro-batch commit.
+        time.sleep(1)
+
+    print_banner(f"{fq(STREAM_TABLE)} — row count after streaming run")
+    print("rows:", spark.table(fq(STREAM_TABLE)).count())
+
+    print_banner(f"DESCRIBE HISTORY {fq(STREAM_TABLE)} (micro-batch commits via UC)")
+    spark.sql(f"DESCRIBE HISTORY {fq(STREAM_TABLE)}").select(
+        "version", "timestamp", "operation", "operationMetrics"
+    ).orderBy("version", ascending=False).show(10, truncate=False)
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/03_spark_streaming.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/03_spark_streaming.py
@@ -125,6 +125,19 @@ def main() -> None:
         "version", "timestamp", "operation", "operationMetrics"
     ).orderBy("version", ascending=False).show(10, truncate=False)
 
+    # ---- Time travel ------------------------------------------------------
+    # Version 0 is the CREATE TABLE that produced an empty `orders_stream`.
+    # Each subsequent version is a streaming micro-batch commit. Showing
+    # both versions side-by-side proves catalog-managed commits also work
+    # for time travel against streaming-written tables.
+    print_banner(f"Time travel: {fq(STREAM_TABLE)} VERSION AS OF 0 vs latest")
+    v0 = spark.sql(
+        f"SELECT count(*) AS n FROM {fq(STREAM_TABLE)} VERSION AS OF 0"
+    ).first()["n"]
+    now = spark.table(fq(STREAM_TABLE)).count()
+    print(f"  rows at version 0 (CREATE TABLE):   {v0:>10,d}")
+    print(f"  rows now (after streaming):         {now:>10,d}")
+
     spark.stop()
 
 

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/04_duckdb_read.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/04_duckdb_read.py
@@ -1,0 +1,51 @@
+"""Read UC managed Delta tables from DuckDB via catalog commits.
+
+Uses the DuckDB `unity_catalog` + `delta` extensions to attach the demo
+catalog and issue SELECTs against managed Delta tables. Demonstrates:
+
+  * Listing tables (SHOW TABLES FROM <catalog>.<schema>)
+  * Standard SELECT against attached UC managed Delta tables
+  * Cross-table JOIN
+
+Catalog commits coordinated by Unity Catalog mean DuckDB sees every row
+that any other engine (Databricks Runtime, external Spark) has
+committed.
+"""
+import duckdb
+
+from _common import UC_CATALOG, UC_SCHEMA, attach_unity_catalog, fq, print_banner
+
+
+def main() -> None:
+    con = duckdb.connect()
+    attach_unity_catalog(con)
+
+    print_banner("DuckDB: list tables in the UC managed schema")
+    rows = con.execute(f"SHOW TABLES FROM {UC_CATALOG}.{UC_SCHEMA}").fetchall()
+    for (name,) in rows:
+        print(f"  {UC_SCHEMA}.{name}")
+
+    print_banner(f"DuckDB: top 5 rows from {fq('orders')}")
+    df = con.execute(f"SELECT * FROM {fq('orders')} LIMIT 5").fetchdf()
+    print(df.to_string(index=False))
+
+    print_banner("DuckDB: TPCH clone row counts")
+    for t in ("customer", "lineitem", "nation", "orders", "part", "partsupp", "region", "supplier"):
+        (n,) = con.execute(f"SELECT count(*) FROM {fq(t)}").fetchone()
+        print(f"  {t:<10s} {n:>12,d}")
+
+    print_banner("DuckDB: cross-table join over UC managed Delta tables")
+    df = con.execute(
+        f"""
+        SELECT n.n_name, count(*) AS customer_count
+        FROM {fq('customer')} c
+        JOIN {fq('nation')}   n ON c.c_nationkey = n.n_nationkey
+        GROUP BY n.n_name
+        ORDER BY customer_count DESC
+        LIMIT 5
+        """
+    ).fetchdf()
+    print(df.to_string(index=False))
+
+if __name__ == "__main__":
+    main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/04_duckdb_read.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/04_duckdb_read.py
@@ -13,7 +13,7 @@ committed.
 """
 import duckdb
 
-from _common import UC_CATALOG, UC_SCHEMA, attach_unity_catalog, fq, print_banner
+from _common import UC_CATALOG, UC_SCHEMA, attach_unity_catalog, fq, print_banner, script_banner
 
 
 def main() -> None:
@@ -48,4 +48,5 @@ def main() -> None:
     print(df.to_string(index=False))
 
 if __name__ == "__main__":
-    main()
+    with script_banner(__file__):
+        main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/05_duckdb_insert.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/05_duckdb_insert.py
@@ -1,0 +1,89 @@
+"""DuckDB INSERT into a UC managed Delta table.
+
+Uses the DuckDB `unity_catalog` + `delta` extensions to insert rows into
+a managed Delta table that lives in Unity Catalog. Every commit flows
+through UC, so Spark and Databricks readers see the inserted rows
+immediately.
+
+Two patterns shown:
+  1. INSERT INTO ... VALUES — single-row inserts.
+  2. INSERT INTO ... SELECT — bulk insert sourced from another UC table.
+
+Idempotent across re-runs of the full pipeline because `run_setup.py`
+drops + recreates the catalog at the start of every cycle.
+"""
+from __future__ import annotations
+
+import duckdb
+
+from _common import attach_unity_catalog, fq, print_banner
+
+
+MARKER_CLERK = "Clerk#external-duckdb"
+
+
+def main() -> None:
+    con = duckdb.connect()
+    attach_unity_catalog(con)
+
+    orders = fq("orders")
+
+    print_banner(f"DuckDB: INSERT INTO {orders} (single-row VALUES)")
+    con.execute(
+        f"""
+        INSERT INTO {orders} (
+            o_orderkey, o_custkey, o_orderstatus, o_totalprice,
+            o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment
+        ) VALUES
+            (9000000301, 1, 'O', 100.00, DATE '2026-04-23', '3-MEDIUM',
+             '{MARKER_CLERK}', 0, 'duckdb single-row insert'),
+            (9000000302, 2, 'O', 200.00, DATE '2026-04-23', '3-MEDIUM',
+             '{MARKER_CLERK}', 0, 'duckdb single-row insert'),
+            (9000000303, 3, 'O', 300.00, DATE '2026-04-23', '5-LOW',
+             '{MARKER_CLERK}', 0, 'duckdb single-row insert');
+        """
+    )
+
+    print_banner(f"DuckDB: INSERT INTO {orders} ... SELECT (bulk)")
+    con.execute(
+        f"""
+        INSERT INTO {orders} (
+            o_orderkey, o_custkey, o_orderstatus, o_totalprice,
+            o_orderdate, o_orderpriority, o_clerk, o_shippriority, o_comment
+        )
+        SELECT
+            o_orderkey + 9_000_000_400 AS o_orderkey,
+            o_custkey,
+            o_orderstatus,
+            o_totalprice,
+            o_orderdate,
+            o_orderpriority,
+            '{MARKER_CLERK}-bulk' AS o_clerk,
+            o_shippriority,
+            'duckdb bulk insert from select' AS o_comment
+        FROM {orders}
+        WHERE o_orderkey BETWEEN 11396166 AND 11396175
+        """
+    )
+
+    print_banner(f"DuckDB: rows now visible in {orders} for DuckDB markers")
+    rows = con.execute(
+        f"""
+        SELECT o_clerk, count(*) AS n
+        FROM {orders}
+        WHERE o_clerk LIKE '{MARKER_CLERK}%'
+        GROUP BY o_clerk
+        ORDER BY o_clerk
+        """
+    ).fetchall()
+    for clerk, n in rows:
+        print(f"  {clerk:<35s} {n}")
+
+    print_banner(
+        "Next: run 06_verify_cross_engine.py to see Spark's DESCRIBE HISTORY "
+        "reflect the DuckDB INSERT commits."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/05_duckdb_insert.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/05_duckdb_insert.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import duckdb
 
-from _common import attach_unity_catalog, fq, print_banner
+from _common import attach_unity_catalog, fq, print_banner, script_banner
 
 
 MARKER_CLERK = "Clerk#external-duckdb"
@@ -86,4 +86,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    with script_banner(__file__):
+        main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/06_verify_cross_engine.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/06_verify_cross_engine.py
@@ -1,0 +1,101 @@
+"""Cross-engine verification — read everything back through external Spark.
+
+Run after the writers (Spark batch + streaming + DuckDB INSERT). This
+script reads through the same external Delta Spark session and dumps
+`DESCRIBE HISTORY` for every table the demo wrote, so you can see the
+mix of `engineInfo` values:
+
+  * `Databricks-Runtime/...` — original CTAS by 00_setup_databricks.sql
+  * `Apache-Spark/4.1.0 Delta-Lake/4.2.0` — external Spark batch + stream
+  * DuckDB INSERT commits — visible alongside the Spark commits on the
+    same `orders` table, proving UC coordinated writes across engines.
+"""
+from _common import build_spark, fq, print_banner
+
+
+MARKER_CLERK = "Clerk#external-duckdb"
+
+
+def _table_exists(spark, name: str) -> bool:
+    return spark._jsparkSession.catalog().tableExists(name)
+
+
+def _describe_history(spark, name: str, limit: int = 10):
+    # DESCRIBE HISTORY can't be used as a subquery, so call it directly then
+    # post-filter with the DataFrame API.
+    return (
+        spark.sql(f"DESCRIBE HISTORY {name}")
+        .orderBy("version", ascending=False)
+        .limit(limit)
+    )
+
+
+def main() -> None:
+    spark = build_spark("06_verify_cross_engine")
+
+    print_banner(f"Spark: DESCRIBE HISTORY {fq('orders')} (Databricks + external commits)")
+    _describe_history(spark, fq("orders")).select(
+        "version", "timestamp", "userName", "operation", "engineInfo"
+    ).show(truncate=False)
+
+    # orders_summary — produced by 02_spark_external_write.py (external CTAS)
+    if _table_exists(spark, fq("orders_summary")):
+        print_banner(f"Spark: DESCRIBE HISTORY {fq('orders_summary')} (external CTAS)")
+        _describe_history(spark, fq("orders_summary"), 3).select(
+            "version", "timestamp", "operation", "engineInfo"
+        ).show(truncate=False)
+    else:
+        print(f"({fq('orders_summary')} not present — run 02_spark_external_write.py)")
+
+    # orders_stream — produced by 09_spark_streaming_external_write.py
+    if _table_exists(spark, fq("orders_stream")):
+        print_banner(
+            f"Spark: DESCRIBE HISTORY {fq('orders_stream')} (external Structured Streaming)"
+        )
+        _describe_history(spark, fq("orders_stream"), 5).select(
+            "version", "timestamp", "operation", "operationMetrics"
+        ).show(truncate=False)
+        print(f"{fq('orders_stream')} row count:", spark.table(fq("orders_stream")).count())
+    else:
+        print(f"({fq('orders_stream')} not present — run 09_spark_streaming_external_write.py)")
+
+    # customer_nation_join — only present if DuckDB scripts 04/05 succeeded.
+    # PRD §10 item 1: uc_catalog DuckDB extension is still pre-GA against
+    # Databricks UC, so this may be absent.
+    if _table_exists(spark, fq("customer_nation_join")):
+        print_banner(
+            f"Spark: read DuckDB-created table {fq('customer_nation_join')}"
+        )
+        spark.table(fq("customer_nation_join")).show(5, truncate=False)
+        print("row count:", spark.table(fq("customer_nation_join")).count())
+
+        print_banner(
+            f"Spark: orders rows inserted by DuckDB (o_clerk='{MARKER_CLERK}')"
+        )
+        spark.sql(
+            f"""
+            SELECT o_orderkey, o_orderstatus, o_totalprice, o_comment
+            FROM {fq('orders')}
+            WHERE o_clerk = '{MARKER_CLERK}'
+            ORDER BY o_orderkey
+            """
+        ).show(truncate=False)
+    else:
+        print(
+            f"({fq('customer_nation_join')} not present — DuckDB extension is pre-GA, "
+            "see PRD §10 item 1)"
+        )
+
+    # Flink-produced table — only present if 07_flink_external_write.py was run
+    if _table_exists(spark, fq("orders_from_flink")):
+        print_banner(f"Spark: DESCRIBE HISTORY {fq('orders_from_flink')} (commits from Flink)")
+        _describe_history(spark, fq("orders_from_flink"), 5).show(truncate=False)
+        print(f"{fq('orders_from_flink')} row count:", spark.table(fq("orders_from_flink")).count())
+    else:
+        print(f"({fq('orders_from_flink')} not present — skip Flink verification)")
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/06_verify_cross_engine.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/06_verify_cross_engine.py
@@ -10,7 +10,7 @@ mix of `engineInfo` values:
   * DuckDB INSERT commits — visible alongside the Spark commits on the
     same `orders` table, proving UC coordinated writes across engines.
 """
-from _common import build_spark, fq, print_banner
+from _common import build_spark, fq, print_banner, script_banner
 
 
 MARKER_CLERK = "Clerk#external-duckdb"
@@ -20,12 +20,12 @@ def _table_exists(spark, name: str) -> bool:
     return spark._jsparkSession.catalog().tableExists(name)
 
 
-def _describe_history(spark, name: str, limit: int = 10):
+def _describe_history(spark, name: str, limit: int = 20):
     # DESCRIBE HISTORY can't be used as a subquery, so call it directly then
-    # post-filter with the DataFrame API.
+    # post-filter with the DataFrame API. Sorted v0 → vN for blog screenshots.
     return (
         spark.sql(f"DESCRIBE HISTORY {name}")
-        .orderBy("version", ascending=False)
+        .orderBy("version")
         .limit(limit)
     )
 
@@ -35,29 +35,29 @@ def main() -> None:
 
     print_banner(f"Spark: DESCRIBE HISTORY {fq('orders')} (Databricks + external commits)")
     _describe_history(spark, fq("orders")).select(
-        "version", "timestamp", "userName", "operation", "engineInfo"
+        "version", "timestamp", "operation", "engineInfo"
     ).show(truncate=False)
 
     # orders_summary — produced by 02_spark_external_write.py (external CTAS)
     if _table_exists(spark, fq("orders_summary")):
         print_banner(f"Spark: DESCRIBE HISTORY {fq('orders_summary')} (external CTAS)")
-        _describe_history(spark, fq("orders_summary"), 3).select(
+        _describe_history(spark, fq("orders_summary"), 5).select(
             "version", "timestamp", "operation", "engineInfo"
         ).show(truncate=False)
     else:
         print(f"({fq('orders_summary')} not present — run 02_spark_external_write.py)")
 
-    # orders_stream — produced by 09_spark_streaming_external_write.py
+    # orders_stream — produced by 03_spark_streaming.py
     if _table_exists(spark, fq("orders_stream")):
         print_banner(
             f"Spark: DESCRIBE HISTORY {fq('orders_stream')} (external Structured Streaming)"
         )
-        _describe_history(spark, fq("orders_stream"), 5).select(
-            "version", "timestamp", "operation", "operationMetrics"
+        _describe_history(spark, fq("orders_stream"), 10).select(
+            "version", "timestamp", "operation", "engineInfo"
         ).show(truncate=False)
         print(f"{fq('orders_stream')} row count:", spark.table(fq("orders_stream")).count())
     else:
-        print(f"({fq('orders_stream')} not present — run 09_spark_streaming_external_write.py)")
+        print(f"({fq('orders_stream')} not present — run 03_spark_streaming.py)")
 
     # customer_nation_join — only present if DuckDB scripts 04/05 succeeded.
     # PRD §10 item 1: uc_catalog DuckDB extension is still pre-GA against
@@ -98,4 +98,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    with script_banner(__file__):
+        main()

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/06_verify_cross_engine.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/06_verify_cross_engine.py
@@ -6,7 +6,7 @@ script reads through the same external Delta Spark session and dumps
 mix of `engineInfo` values:
 
   * `Databricks-Runtime/...` — original CTAS by 00_setup_databricks.sql
-  * `Apache-Spark/4.1.0 Delta-Lake/4.2.0` — external Spark batch + stream
+  * `Apache-Spark/4.1.1 Delta-Lake/4.2.0` — external Spark batch + stream
   * DuckDB INSERT commits — visible alongside the Spark commits on the
     same `orders` table, proving UC coordinated writes across engines.
 """
@@ -59,40 +59,19 @@ def main() -> None:
     else:
         print(f"({fq('orders_stream')} not present — run 03_spark_streaming.py)")
 
-    # customer_nation_join — only present if DuckDB scripts 04/05 succeeded.
-    # PRD §10 item 1: uc_catalog DuckDB extension is still pre-GA against
-    # Databricks UC, so this may be absent.
-    if _table_exists(spark, fq("customer_nation_join")):
-        print_banner(
-            f"Spark: read DuckDB-created table {fq('customer_nation_join')}"
-        )
-        spark.table(fq("customer_nation_join")).show(5, truncate=False)
-        print("row count:", spark.table(fq("customer_nation_join")).count())
-
-        print_banner(
-            f"Spark: orders rows inserted by DuckDB (o_clerk='{MARKER_CLERK}')"
-        )
-        spark.sql(
-            f"""
-            SELECT o_orderkey, o_orderstatus, o_totalprice, o_comment
-            FROM {fq('orders')}
-            WHERE o_clerk = '{MARKER_CLERK}'
-            ORDER BY o_orderkey
-            """
-        ).show(truncate=False)
-    else:
-        print(
-            f"({fq('customer_nation_join')} not present — DuckDB extension is pre-GA, "
-            "see PRD §10 item 1)"
-        )
-
-    # Flink-produced table — only present if 07_flink_external_write.py was run
-    if _table_exists(spark, fq("orders_from_flink")):
-        print_banner(f"Spark: DESCRIBE HISTORY {fq('orders_from_flink')} (commits from Flink)")
-        _describe_history(spark, fq("orders_from_flink"), 5).show(truncate=False)
-        print(f"{fq('orders_from_flink')} row count:", spark.table(fq("orders_from_flink")).count())
-    else:
-        print(f"({fq('orders_from_flink')} not present — skip Flink verification)")
+    # DuckDB-inserted rows visible to external Spark (cross-engine read of
+    # rows committed by another engine through UC).
+    print_banner(
+        f"Spark: orders rows inserted by DuckDB (o_clerk LIKE '{MARKER_CLERK}%')"
+    )
+    spark.sql(
+        f"""
+        SELECT o_orderkey, o_clerk, o_orderstatus, o_totalprice, o_comment
+        FROM {fq('orders')}
+        WHERE o_clerk LIKE '{MARKER_CLERK}%'
+        ORDER BY o_orderkey
+        """
+    ).show(truncate=False)
 
     spark.stop()
 

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/99_cleanup.sql
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/99_cleanup.sql
@@ -1,0 +1,8 @@
+-- ============================================================================
+-- 99_cleanup.sql
+-- Drops everything 00_setup_databricks.sql created.
+-- Run inside Databricks with the same principal used for setup.
+-- ============================================================================
+
+DROP SCHEMA IF EXISTS uc_ext_access_demo.tpch_managed CASCADE;
+DROP CATALOG IF EXISTS uc_ext_access_demo CASCADE;

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/README.md
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/README.md
@@ -16,21 +16,29 @@ consistent transaction log no matter which engine wrote the rows.
 
 ## Quick start
 
+### 1. One-time setup
+
 ```bash
+# from the folder containing this README
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 
 cp .env.example .env
-# Edit .env — fill in your workspace URL, CLI profile, secret scope
+# Edit .env — fill in your workspace URL, CLI profile, secret-scope
 # keys, warehouse id, and AWS region. See `.env.example` for what
 # each value means.
-
-python run_all.py        # idempotent end-to-end pipeline (~6 min)
 ```
 
-`run_all.py` runs in this order:
+### 2. Run the whole pipeline end-to-end
+
+```bash
+source .venv/bin/activate              # if not already in this shell
+python run_all.py                      # idempotent — ~6 minutes
+```
+
+`run_all.py` runs these in order:
 
 1. `run_setup.py` — DROP + CREATE the demo catalog, clone 8
    `samples.tpch` tables as managed Delta, apply grants.
@@ -39,11 +47,45 @@ python run_all.py        # idempotent end-to-end pipeline (~6 min)
 4. `03_spark_streaming.py` — external Spark Structured Streaming.
 5. `04_duckdb_read.py` — DuckDB SELECT + JOIN against UC tables.
 6. `05_duckdb_insert.py` — DuckDB INSERT (`VALUES` and `INSERT … SELECT`).
-7. `06_verify_cross_engine.py` — cross-engine `DESCRIBE HISTORY` showing
-   the mix of `engineInfo` values across the catalog.
+7. `06_verify_cross_engine.py` — cross-engine `DESCRIBE HISTORY`
+   showing the mix of `engineInfo` values across the catalog.
 
-Skip stages with the `SKIP_SCRIPTS` env var, e.g.
-`SKIP_SCRIPTS=streaming python run_all.py`.
+Skip stages with `SKIP_SCRIPTS`:
+
+```bash
+SKIP_SCRIPTS=streaming python run_all.py            # skip the 30s streaming step
+SKIP_SCRIPTS=setup,spark_read python run_all.py     # reuse current catalog state
+SKIP_SCRIPTS=duckdb_read,duckdb_insert python run_all.py   # spark only
+```
+
+Skip names map to the `STEPS` list in `run_all.py`:
+`setup`, `spark_read`, `spark_write`, `streaming`, `duckdb_read`,
+`duckdb_insert`, `verify`.
+
+### 3. Or run any script individually
+
+```bash
+source .venv/bin/activate
+
+python run_setup.py                  # DROP + CREATE catalog, clone TPCH, grants
+python 01_spark_external_read.py     # external Spark read
+python 02_spark_external_write.py    # external Spark APPEND + CTAS
+python 03_spark_streaming.py         # external Spark Structured Streaming (~30s)
+python 04_duckdb_read.py             # DuckDB SELECT + JOIN
+python 05_duckdb_insert.py           # DuckDB INSERT
+python 06_verify_cross_engine.py     # cross-engine DESCRIBE HISTORY
+```
+
+`run_setup.py` must run at least once before any other script. After
+that, the rest can run in any order — each one uses idempotent
+marker patterns or DROP+CREATE so you can re-run the same script as
+many times as you want without breaking state.
+
+Override the streaming duration:
+
+```bash
+STREAM_DURATION_SECONDS=120 python 03_spark_streaming.py
+```
 
 ## Prerequisites
 
@@ -76,18 +118,6 @@ Copy `.env.example` to `.env` and fill in:
 
 If you don't have a CLI profile locally, set `DATABRICKS_CLIENT_ID`
 and `DATABRICKS_CLIENT_SECRET` directly. See `.env.example`.
-
-## Run stages individually
-
-| Command | What it does |
-|---|---|
-| `python run_setup.py` | DROP + CREATE catalog, seed TPCH, apply grants. |
-| `python 01_spark_external_read.py` | External Spark reads the TPCH clones, dumps `DESCRIBE HISTORY orders`. |
-| `python 02_spark_external_write.py` | Removes prior marker rows, appends 2 new rows to `orders`, CTAS `orders_summary`. |
-| `python 03_spark_streaming.py` | Drops + recreates `orders_stream`, streams ~30s. Override duration with `STREAM_DURATION_SECONDS=60`. |
-| `python 04_duckdb_read.py` | DuckDB lists tables, SELECT, cross-table JOIN. |
-| `python 05_duckdb_insert.py` | DuckDB INSERT into the managed `orders` table — both `VALUES` and `INSERT … SELECT`. |
-| `python 06_verify_cross_engine.py` | Cross-engine `DESCRIBE HISTORY` verify across `orders`, `orders_summary`, `orders_stream`. |
 
 ## Cleanup
 

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/README.md
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/README.md
@@ -1,0 +1,193 @@
+# External Access to Unity Catalog Managed Delta Tables — Demo
+
+Companion code for the community blog on the **External Access to
+Unity Catalog Managed Delta Tables (Beta)**.
+
+The pipeline shows that catalog-managed Delta commits work end-to-end
+from outside Databricks, across multiple external engines, against
+Unity Catalog managed Delta tables:
+
+- **External Apache Spark** — batch read/write + Structured Streaming
+- **DuckDB** — SELECT, JOIN, INSERT (via the `unity_catalog` + `delta` core extensions)
+
+Every commit produced by an external engine is coordinated by Unity
+Catalog, so writers don't step on each other and readers see a single,
+consistent transaction log no matter which engine wrote the rows.
+
+## Quick start
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+cp .env.example .env
+# Edit .env — fill in your workspace URL, CLI profile, secret scope
+# keys, warehouse id, and AWS region. See `.env.example` for what
+# each value means.
+
+python run_all.py        # idempotent end-to-end pipeline (~6 min)
+```
+
+`run_all.py` runs in this order:
+
+1. `run_setup.py` — DROP + CREATE the demo catalog, clone 8
+   `samples.tpch` tables as managed Delta, apply grants.
+2. `01_spark_external_read.py` — external Spark batch read.
+3. `02_spark_external_write.py` — external Spark APPEND + CTAS.
+4. `03_spark_streaming.py` — external Spark Structured Streaming.
+5. `04_duckdb_read.py` — DuckDB SELECT + JOIN against UC tables.
+6. `05_duckdb_insert.py` — DuckDB INSERT (`VALUES` and `INSERT … SELECT`).
+7. `06_verify_cross_engine.py` — cross-engine `DESCRIBE HISTORY` showing
+   the mix of `engineInfo` values across the catalog.
+
+Skip stages with the `SKIP_SCRIPTS` env var, e.g.
+`SKIP_SCRIPTS=streaming python run_all.py`.
+
+## Prerequisites
+
+- A Databricks workspace with Unity Catalog and the **External Access
+  to Unity Catalog Managed Delta Table** preview enabled (Settings →
+  Previews).
+- *External Data Access* enabled on the metastore (Governance →
+  Metastore details).
+- A service principal with an OAuth client_id + client_secret.
+  Demos use **M2M OAuth only** — no PATs.
+- A serverless SQL warehouse (used by `run_setup.py` to execute the
+  setup SQL).
+- Python 3.11+ and Java 17+ on the local machine.
+- Databricks CLI profile with permission to `CREATE CATALOG` (used by
+  `run_setup.py` — the demo SP usually cannot).
+
+## Configure `.env`
+
+Copy `.env.example` to `.env` and fill in:
+
+| Variable | Purpose |
+|---|---|
+| `DATABRICKS_HOST` | Workspace URL, no trailing slash. |
+| `DATABRICKS_PROFILE` | CLI profile used by `run_setup.py` (must have `CREATE CATALOG`). |
+| `SP_SECRET_SCOPE`, `SP_CLIENT_ID_SECRET_KEY`, `SP_CLIENT_SECRET_SECRET_KEY` | Databricks secret scope + keys holding the SP OAuth credentials. |
+| `DATABRICKS_WAREHOUSE_ID` | Serverless SQL warehouse id used to execute the setup SQL. |
+| `UC_CATALOG`, `UC_SCHEMA` | Optional — default to `uc_ext_access_demo` / `tpch_managed`. |
+| `AWS_REGION` | S3 region of the UC bucket (e.g. `us-west-2`). |
+| `SPARK_REPOSITORIES` | Optional alternate Maven mirror, comma-separated. |
+
+If you don't have a CLI profile locally, set `DATABRICKS_CLIENT_ID`
+and `DATABRICKS_CLIENT_SECRET` directly. See `.env.example`.
+
+## Run stages individually
+
+| Command | What it does |
+|---|---|
+| `python run_setup.py` | DROP + CREATE catalog, seed TPCH, apply grants. |
+| `python 01_spark_external_read.py` | External Spark reads the TPCH clones, dumps `DESCRIBE HISTORY orders`. |
+| `python 02_spark_external_write.py` | Removes prior marker rows, appends 2 new rows to `orders`, CTAS `orders_summary`. |
+| `python 03_spark_streaming.py` | Drops + recreates `orders_stream`, streams ~30s. Override duration with `STREAM_DURATION_SECONDS=60`. |
+| `python 04_duckdb_read.py` | DuckDB lists tables, SELECT, cross-table JOIN. |
+| `python 05_duckdb_insert.py` | DuckDB INSERT into the managed `orders` table — both `VALUES` and `INSERT … SELECT`. |
+| `python 06_verify_cross_engine.py` | Cross-engine `DESCRIBE HISTORY` verify across `orders`, `orders_summary`, `orders_stream`. |
+
+## Cleanup
+
+`run_setup.py` already drops the catalog at the start of every run, so
+cleanup between demos happens automatically. To remove the catalog at
+the end of a session:
+
+```bash
+databricks api post /api/2.0/sql/statements \
+  --profile "$DATABRICKS_PROFILE" \
+  --json "{\"warehouse_id\": \"$DATABRICKS_WAREHOUSE_ID\", \"statement\": \"DROP CATALOG IF EXISTS ${UC_CATALOG:-uc_ext_access_demo} CASCADE\", \"wait_timeout\": \"50s\"}"
+```
+
+Or paste `99_cleanup.sql` into the Databricks SQL editor.
+
+## Architecture notes
+
+`_common.py` centralises everything shared:
+
+- `.env` is loaded at import time. All tuning knobs — version pins,
+  mirror URLs, region — are env vars so the scripts are portable
+  across workspaces.
+- `_resolve_sp_credentials()` supports two paths: direct env vars
+  (`DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET`) or fetch from
+  a Databricks secret scope using the CLI profile. Direct env wins.
+- `get_demo_principal()` returns the SP's application_id, derived
+  from its OAuth client_id (so `DEMO_PRINCIPAL` doesn't need to be
+  set separately unless grants should land on a different principal).
+- `build_spark()` wires the external `SparkSession` with the latest
+  `delta-spark`, `unitycatalog-spark`, and `hadoop-aws` (matching the
+  hadoop client version bundled with PySpark) via `--packages`. UC is
+  registered as a Spark catalog with `auth.type=oauth`,
+  `auth.oauth.uri=$HOST/oidc/v1/token`, and
+  `renewCredential.enabled=true` — the connector mints and refreshes
+  its own tokens; no pre-fetched token is baked into the session.
+- `attach_unity_catalog()` installs the `unity_catalog` + `delta`
+  DuckDB core extensions, creates an anonymous UC `SECRET` with the
+  OAuth token + workspace-root `ENDPOINT`, and `ATTACH`es the catalog.
+
+## Version pins (defaults in `_common.py` / `requirements.txt`)
+
+| Component | Pin | Override |
+|---|---|---|
+| Scala | 2.13 | `SCALA_VERSION` |
+| delta-spark | 4.2.0 | `DELTA_SPARK_VERSION` |
+| unitycatalog-spark | 0.4.1 | `UC_SPARK_VERSION` |
+| hadoop-aws | 3.4.2 | `HADOOP_AWS_VERSION` |
+| pyspark | 4.1.1 | pinned in `requirements.txt` |
+| duckdb | 1.5.2 | pinned in `requirements.txt` |
+| AWS region | us-west-2 | `AWS_REGION` |
+
+When bumping `pyspark`, re-check what `hadoop-client-api-*.jar` it
+ships and align `hadoop-aws` to that version.
+
+Point Spark at a different Maven mirror with `SPARK_REPOSITORIES` —
+useful when `repo1.maven.org` is blocked at the network layer:
+
+```bash
+SPARK_REPOSITORIES="https://maven-central.storage.googleapis.com/maven2"
+```
+
+## DuckDB operations covered
+
+`04_duckdb_read.py` exercises:
+
+- Listing tables — `SHOW TABLES FROM <catalog>.<schema>`
+- Standard SELECT against UC managed Delta tables
+- Cross-table JOIN
+
+`05_duckdb_insert.py` exercises:
+
+- `INSERT INTO <managed table> ... VALUES (...)`
+- `INSERT INTO <managed table> ... SELECT ...`
+
+See the [official `unity_catalog` extension docs](https://duckdb.org/docs/current/core_extensions/unity_catalog)
+for the full feature list as the extension evolves.
+
+## Troubleshooting
+
+- **`PERMISSION_DENIED: external use of schema`** — the principal is
+  missing `EXTERNAL_USE_SCHEMA`. Re-run `run_setup.py` to reapply the
+  grants.
+- **`Managed table creation requires table property
+  'delta.feature.catalogManaged'='supported'`** — when creating a new
+  managed Delta table from external Spark, the DDL must include
+  `USING DELTA TBLPROPERTIES ('delta.feature.catalogManaged' =
+  'supported')`. Scripts 02 and 03 already do this.
+- **`uri must be specified for Unity Catalog 'spark_catalog'`** —
+  keep `spark_catalog` on `DeltaCatalog`, not `UCSingleCatalog`.
+  `_common.build_spark` sets this.
+- **`No FileSystem for scheme "s3"`** — UC returns `s3://` URIs and
+  Hadoop 3.4 only ships `s3a://`. `_common.build_spark` already maps
+  `fs.s3.impl` to `S3AFileSystem`.
+- **`Connection refused` on Maven Central** — `/etc/hosts` or a proxy
+  is pinning `repo1.maven.org` to `127.0.0.1`. Set
+  `SPARK_REPOSITORIES="https://maven-central.storage.googleapis.com/maven2"`
+  or another reachable mirror.
+
+## Validated
+
+End-to-end pipeline (setup → Spark read/write/streaming → DuckDB
+read/insert → verify) has been run successfully against two
+preview-enrolled Databricks workspaces.

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/README.md
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/README.md
@@ -7,62 +7,114 @@ The pipeline shows that catalog-managed Delta commits work end-to-end
 from outside Databricks, across multiple external engines, against
 Unity Catalog managed Delta tables:
 
-- **External Apache Spark** — batch read/write + Structured Streaming
-- **DuckDB** — SELECT, JOIN, INSERT (via the `unity_catalog` + `delta` core extensions)
+- **External Apache Spark 4.1.1 + Delta Lake 4.2.0 + Unity Catalog 0.4.1** — read, append, CTAS, and Structured Streaming writes.
+- **DuckDB 1.5.2** — SELECT, JOIN, INSERT (via the `unity_catalog` + `delta` core extensions).
 
 Every commit produced by an external engine is coordinated by Unity
 Catalog, so writers don't step on each other and readers see a single,
 consistent transaction log no matter which engine wrote the rows.
+Cross-engine consistency is shown by `DESCRIBE HISTORY` at the end of
+the run, where every commit is attributed to the engine that produced
+it (Databricks Runtime, external Apache Spark, or DuckDB).
 
-## Quick start
+## Prerequisites
 
-### 1. One-time setup
+- Databricks workspace with Unity Catalog.
+- Workspace enrolled in the **"External Access to Unity Catalog Managed
+  Delta Table"** preview (Settings → Previews).
+- External Data Access enabled on the metastore (Governance →
+  Metastore details).
+- A service principal with an OAuth client_id + client_secret (Workspace
+  admin → Identity and access → Service principals → OAuth secrets).
+  M2M OAuth only — no PATs.
+- The setup script grants the SP `USE CATALOG`, `USE SCHEMA`, `SELECT`,
+  `MODIFY`, `CREATE TABLE`, and **`EXTERNAL_USE_SCHEMA`** on the demo
+  schema.
+- Local machine with Python **3.11+** and Java **17+**.
+- A Databricks CLI profile with permission to `CREATE CATALOG` (used by
+  `run_setup.py` — the SP usually cannot).
+
+## Step-by-step — first-time setup
+
+All commands assume you are in the `scripts/` directory.
+
+### 1. Python venv and deps
 
 ```bash
-# from the folder containing this README
+cd scripts
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
-
-cp .env.example .env
-# Edit .env — fill in your workspace URL, CLI profile, secret-scope
-# keys, warehouse id, and AWS region. See `.env.example` for what
-# each value means.
 ```
 
-### 2. Run the whole pipeline end-to-end
+### 2. Configure `.env`
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env`. Minimum values:
+
+| Variable | Purpose |
+|---|---|
+| `DATABRICKS_HOST` | Workspace URL, no trailing slash |
+| `DATABRICKS_PROFILE` | CLI profile used by `run_setup.py` (must have `CREATE CATALOG`) |
+| `SP_SECRET_SCOPE`, `SP_CLIENT_ID_SECRET_KEY`, `SP_CLIENT_SECRET_SECRET_KEY` | Databricks secret scope + keys holding the SP OAuth credentials |
+| `DATABRICKS_WAREHOUSE_ID` | Serverless SQL warehouse id used to execute the setup SQL |
+| `UC_CATALOG`, `UC_SCHEMA` | Optional — default to `uc_ext_access_demo` / `tpch_managed` |
+| `AWS_REGION` | S3 region of the UC bucket (e.g. `us-west-2`) |
+| `SPARK_REPOSITORIES` | Optional — alternate Maven mirror, comma-separated |
+
+Path B alternative: if you don't have a CLI profile locally, set
+`DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` directly. See
+`.env.example` for the full list.
+
+### 3. Run the whole pipeline end-to-end
 
 ```bash
 source .venv/bin/activate              # if not already in this shell
 python run_all.py                      # idempotent — ~6 minutes
 ```
 
-`run_all.py` runs these in order:
+`run_all.py` runs these 9 steps in order. The `orders` version column
+on the right shows what each step contributes to the final transaction
+log, which is the screenshot the blog uses:
 
-1. `run_setup.py` — DROP + CREATE the demo catalog, clone 8
-   `samples.tpch` tables as managed Delta, apply grants.
-2. `01_spark_external_read.py` — external Spark batch read.
-3. `02_spark_external_write.py` — external Spark APPEND + CTAS.
-4. `03_spark_streaming.py` — external Spark Structured Streaming.
-5. `04_duckdb_read.py` — DuckDB SELECT + JOIN against UC tables.
-6. `05_duckdb_insert.py` — DuckDB INSERT (`VALUES` and `INSERT … SELECT`).
-7. `06_verify_cross_engine.py` — cross-engine `DESCRIBE HISTORY`
-   showing the mix of `engineInfo` values across the catalog.
+| # | Step | Script | `orders` |
+|---|------|--------|----------|
+| 1 | `setup`            | `run_setup.py`                | v0 (Databricks CTAS) |
+| 2 | `spark_read`       | `01_spark_external_read.py`   | — |
+| 3 | `spark_write`      | `02_spark_external_write.py`  | v1 (external Spark APPEND) |
+| 4 | `streaming`        | `03_spark_streaming.py`       | — (writes to `orders_stream`) |
+| 5 | `duckdb_read`      | `04_duckdb_read.py`           | — |
+| 6 | `duckdb_insert`    | `05_duckdb_insert.py`         | v2, v3 (DuckDB INSERTs) |
+| 7 | `spark_write_redo` | `02_spark_external_write.py`  | v4 (DELETE), v5 (APPEND) |
+| 8 | `verify`           | `06_verify_cross_engine.py`   | — (reads only) |
+| 9 | `cleanup`          | `run_cleanup.py`              | DROP catalog |
 
+The second pass of `02_spark_external_write.py` (step 7) is intentional
+— the first pass's DELETE is a no-op on a fresh catalog (no markers to
+delete), so the second pass creates the v4 DELETE commit and the v5
+WRITE commit that complete the 6-row mixed-engine history (Databricks
+Runtime + DuckDB + external Spark).
+
+The first run is ~6–8 minutes (most of it is Spark JVM startup + Ivy
+JAR resolution + the 30s streaming step). Subsequent runs are similar.
 Skip stages with `SKIP_SCRIPTS`:
 
 ```bash
-SKIP_SCRIPTS=streaming python run_all.py            # skip the 30s streaming step
-SKIP_SCRIPTS=setup,spark_read python run_all.py     # reuse current catalog state
-SKIP_SCRIPTS=duckdb_read,duckdb_insert python run_all.py   # spark only
+SKIP_SCRIPTS=streaming python run_all.py                  # skip the 30s streaming step
+SKIP_SCRIPTS=cleanup python run_all.py                    # leave the catalog in place to inspect afterwards
+SKIP_SCRIPTS=setup,spark_read python run_all.py           # reuse current catalog state
+SKIP_SCRIPTS=duckdb_read,duckdb_insert python run_all.py  # spark only
 ```
 
 Skip names map to the `STEPS` list in `run_all.py`:
 `setup`, `spark_read`, `spark_write`, `streaming`, `duckdb_read`,
-`duckdb_insert`, `verify`.
+`duckdb_insert`, `spark_write_redo`, `verify`, `cleanup`.
 
-### 3. Or run any script individually
+### 4. Or run any script individually
 
 ```bash
 source .venv/bin/activate
@@ -74,12 +126,14 @@ python 03_spark_streaming.py         # external Spark Structured Streaming (~30s
 python 04_duckdb_read.py             # DuckDB SELECT + JOIN
 python 05_duckdb_insert.py           # DuckDB INSERT
 python 06_verify_cross_engine.py     # cross-engine DESCRIBE HISTORY
+python run_cleanup.py                # DROP catalog + schema (when done)
 ```
 
 `run_setup.py` must run at least once before any other script. After
 that, the rest can run in any order — each one uses idempotent
 marker patterns or DROP+CREATE so you can re-run the same script as
-many times as you want without breaking state.
+many times as you want without breaking state. Each script prints
+START/END banners around its run for easy navigation.
 
 Override the streaming duration:
 
@@ -87,53 +141,20 @@ Override the streaming duration:
 STREAM_DURATION_SECONDS=120 python 03_spark_streaming.py
 ```
 
-## Prerequisites
+### 5. Cleanup
 
-- A Databricks workspace with Unity Catalog and the **External Access
-  to Unity Catalog Managed Delta Table** preview enabled (Settings →
-  Previews).
-- *External Data Access* enabled on the metastore (Governance →
-  Metastore details).
-- A service principal with an OAuth client_id + client_secret.
-  Demos use **M2M OAuth only** — no PATs.
-- A serverless SQL warehouse (used by `run_setup.py` to execute the
-  setup SQL).
-- Python 3.11+ and Java 17+ on the local machine.
-- Databricks CLI profile with permission to `CREATE CATALOG` (used by
-  `run_setup.py` — the demo SP usually cannot).
-
-## Configure `.env`
-
-Copy `.env.example` to `.env` and fill in:
-
-| Variable | Purpose |
-|---|---|
-| `DATABRICKS_HOST` | Workspace URL, no trailing slash. |
-| `DATABRICKS_PROFILE` | CLI profile used by `run_setup.py` (must have `CREATE CATALOG`). |
-| `SP_SECRET_SCOPE`, `SP_CLIENT_ID_SECRET_KEY`, `SP_CLIENT_SECRET_SECRET_KEY` | Databricks secret scope + keys holding the SP OAuth credentials. |
-| `DATABRICKS_WAREHOUSE_ID` | Serverless SQL warehouse id used to execute the setup SQL. |
-| `UC_CATALOG`, `UC_SCHEMA` | Optional — default to `uc_ext_access_demo` / `tpch_managed`. |
-| `AWS_REGION` | S3 region of the UC bucket (e.g. `us-west-2`). |
-| `SPARK_REPOSITORIES` | Optional alternate Maven mirror, comma-separated. |
-
-If you don't have a CLI profile locally, set `DATABRICKS_CLIENT_ID`
-and `DATABRICKS_CLIENT_SECRET` directly. See `.env.example`.
-
-## Cleanup
-
-`run_setup.py` already drops the catalog at the start of every run, so
-cleanup between demos happens automatically. To remove the catalog at
-the end of a session:
+`run_setup.py` already drops the catalog at the start of every run,
+and `run_all.py` ends with a dedicated `cleanup` step (`run_cleanup.py`)
+that drops the demo catalog + schema entirely. To clean up manually
+after running scripts individually:
 
 ```bash
-databricks api post /api/2.0/sql/statements \
-  --profile "$DATABRICKS_PROFILE" \
-  --json "{\"warehouse_id\": \"$DATABRICKS_WAREHOUSE_ID\", \"statement\": \"DROP CATALOG IF EXISTS ${UC_CATALOG:-uc_ext_access_demo} CASCADE\", \"wait_timeout\": \"50s\"}"
+python run_cleanup.py
 ```
 
 Or paste `99_cleanup.sql` into the Databricks SQL editor.
 
-## Architecture notes
+## Architecture and design notes
 
 `_common.py` centralises everything shared:
 
@@ -141,25 +162,31 @@ Or paste `99_cleanup.sql` into the Databricks SQL editor.
   mirror URLs, region — are env vars so the scripts are portable
   across workspaces.
 - `_resolve_sp_credentials()` supports two paths: direct env vars
-  (`DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET`) or fetch from
-  a Databricks secret scope using the CLI profile. Direct env wins.
+  (`DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET`) or fetch from a
+  Databricks secret scope using the CLI profile. Direct env wins.
 - `get_demo_principal()` returns the SP's application_id, derived
-  from its OAuth client_id (so `DEMO_PRINCIPAL` doesn't need to be
-  set separately unless grants should land on a different principal).
-- `build_spark()` wires the external `SparkSession` with the latest
-  `delta-spark`, `unitycatalog-spark`, and `hadoop-aws` (matching the
-  hadoop client version bundled with PySpark) via `--packages`. UC is
-  registered as a Spark catalog with `auth.type=oauth`,
-  `auth.oauth.uri=$HOST/oidc/v1/token`, and
-  `renewCredential.enabled=true` — the connector mints and refreshes
-  its own tokens; no pre-fetched token is baked into the session.
+  from its OAuth client_id (so `DEMO_PRINCIPAL` doesn't need to be set
+  separately unless you want to grant to a *different* principal).
+- `build_spark()` wires the external `SparkSession` with:
+  - `--packages io.delta:delta-spark_2.13:4.2.0,
+    io.unitycatalog:unitycatalog-spark_2.13:0.4.1,
+    org.apache.hadoop:hadoop-aws:3.4.2`
+  - UC as a catalog with `auth.type=oauth`,
+    `auth.oauth.uri=$HOST/oidc/v1/token`, `auth.oauth.clientId`,
+    `auth.oauth.clientSecret`, `renewCredential.enabled=true` — the
+    connector mints and refreshes its own tokens; nothing pre-fetched
+    is baked into the session.
+  - `spark.sql.defaultCatalog=$UC_CATALOG` so unqualified queries hit UC.
+  - `spark.hadoop.fs.s3.impl = S3AFileSystem` — UC hands back `s3://`
+    URIs; Hadoop 3.4 only ships `s3a://`, so the scheme is routed
+    through S3A.
 - `attach_unity_catalog()` installs the `unity_catalog` + `delta`
   DuckDB core extensions, creates an anonymous UC `SECRET` with the
   OAuth token + workspace-root `ENDPOINT`, and `ATTACH`es the catalog.
 
-## Version pins (defaults in `_common.py` / `requirements.txt`)
+## Version pins (defaults in `_common.py`)
 
-| Component | Pin | Override |
+| Component | Pin | Env override |
 |---|---|---|
 | Scala | 2.13 | `SCALA_VERSION` |
 | delta-spark | 4.2.0 | `DELTA_SPARK_VERSION` |
@@ -169,15 +196,35 @@ Or paste `99_cleanup.sql` into the Databricks SQL editor.
 | duckdb | 1.5.2 | pinned in `requirements.txt` |
 | AWS region | us-west-2 | `AWS_REGION` |
 
-When bumping `pyspark`, re-check what `hadoop-client-api-*.jar` it
-ships and align `hadoop-aws` to that version.
+Point Spark at a different Maven mirror with `SPARK_REPOSITORIES`
+(comma-separated). Useful when `repo1.maven.org` is blocked at the
+network layer — e.g.
+`https://maven-central.storage.googleapis.com/maven2`.
 
-Point Spark at a different Maven mirror with `SPARK_REPOSITORIES` —
-useful when `repo1.maven.org` is blocked at the network layer:
+## Troubleshooting
 
-```bash
-SPARK_REPOSITORIES="https://maven-central.storage.googleapis.com/maven2"
-```
+- **`PERMISSION_DENIED: external use of schema`** — the principal is
+  missing `EXTERNAL_USE_SCHEMA`. Re-run `run_setup.py` to reapply the
+  grants block.
+- **`Managed table creation requires table property
+  'delta.feature.catalogManaged'='supported'`** — creating a managed
+  Delta table from external Spark requires `USING DELTA TBLPROPERTIES
+  ('delta.feature.catalogManaged' = 'supported')`. Scripts 02 and 03
+  already include this; add it if you write new DDL.
+- **`uri must be specified for Unity Catalog 'spark_catalog'`** —
+  `spark_catalog` should stay on `DeltaCatalog`, not `UCSingleCatalog`.
+  `_common.build_spark` sets this.
+- **`No FileSystem for scheme "s3"`** — UC returns `s3://` URIs.
+  `_common.build_spark` already maps `fs.s3.impl` to `S3AFileSystem`.
+- **`Connection refused` on Maven Central** — `/etc/hosts` or a proxy
+  is pinning `repo1.maven.org` to `127.0.0.1`. Set
+  `SPARK_REPOSITORIES="https://maven-central.storage.googleapis.com/maven2"`
+  or another reachable mirror.
+- **Spark JVM / Ivy logs hidden** — `_common.build_spark` suppresses
+  Spark JVM startup banners and Ivy package-resolution chatter so the
+  scripts produce clean, screenshot-friendly output. Set
+  `DEMO_VERBOSE=1` if you need the full noise to debug a classpath
+  issue (e.g. a missing JAR).
 
 ## DuckDB operations covered
 
@@ -195,29 +242,12 @@ SPARK_REPOSITORIES="https://maven-central.storage.googleapis.com/maven2"
 See the [official `unity_catalog` extension docs](https://duckdb.org/docs/current/core_extensions/unity_catalog)
 for the full feature list as the extension evolves.
 
-## Troubleshooting
-
-- **`PERMISSION_DENIED: external use of schema`** — the principal is
-  missing `EXTERNAL_USE_SCHEMA`. Re-run `run_setup.py` to reapply the
-  grants.
-- **`Managed table creation requires table property
-  'delta.feature.catalogManaged'='supported'`** — when creating a new
-  managed Delta table from external Spark, the DDL must include
-  `USING DELTA TBLPROPERTIES ('delta.feature.catalogManaged' =
-  'supported')`. Scripts 02 and 03 already do this.
-- **`uri must be specified for Unity Catalog 'spark_catalog'`** —
-  keep `spark_catalog` on `DeltaCatalog`, not `UCSingleCatalog`.
-  `_common.build_spark` sets this.
-- **`No FileSystem for scheme "s3"`** — UC returns `s3://` URIs and
-  Hadoop 3.4 only ships `s3a://`. `_common.build_spark` already maps
-  `fs.s3.impl` to `S3AFileSystem`.
-- **`Connection refused` on Maven Central** — `/etc/hosts` or a proxy
-  is pinning `repo1.maven.org` to `127.0.0.1`. Set
-  `SPARK_REPOSITORIES="https://maven-central.storage.googleapis.com/maven2"`
-  or another reachable mirror.
-
 ## Validated
 
 End-to-end pipeline (setup → Spark read/write/streaming → DuckDB
-read/insert → verify) has been run successfully against two
-preview-enrolled Databricks workspaces.
+read/insert → spark_write_redo → verify → cleanup) has been run
+successfully against a preview-enrolled Databricks workspace.
+
+## License
+
+TBD before publication.

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/_common.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/_common.py
@@ -1,0 +1,292 @@
+"""Shared helpers for the External Access Beta demo scripts.
+
+Reads configuration from environment variables (and an optional .env file).
+Keeps auth + catalog naming in one place so each demo script stays focused
+on the operation it is demonstrating.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _load_dotenv() -> None:
+    """Minimal .env loader — no external dependency."""
+    env_path = Path(__file__).with_name(".env")
+    if not env_path.exists():
+        return
+    for line in env_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+_load_dotenv()
+
+
+def require(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(
+            f"Missing required environment variable: {name}. "
+            "Set it in your shell or in scripts/.env (see .env.example)."
+        )
+    return value
+
+
+# --- Workspace / UC coordinates ---------------------------------------------
+
+DATABRICKS_HOST = require("DATABRICKS_HOST").rstrip("/")
+
+UC_CATALOG = os.environ.get("UC_CATALOG", "uc_ext_access_demo")
+UC_SCHEMA = os.environ.get("UC_SCHEMA", "tpch_managed")
+
+
+# --- M2M OAuth --------------------------------------------------------------
+
+_SP_CREDS_CACHE: tuple[str, str] | None = None
+
+
+def _resolve_sp_credentials() -> tuple[str, str]:
+    """Return (client_id, client_secret) for the demo service principal.
+
+    Two resolution paths, tried in order:
+
+    1. **Databricks secrets** (preferred for internal use): set
+       DATABRICKS_PROFILE + SP_SECRET_SCOPE + SP_CLIENT_ID_SECRET_KEY +
+       SP_CLIENT_SECRET_SECRET_KEY in .env. We authenticate to the workspace
+       using the named CLI profile (e.g. from `databricks auth login`) and
+       read the SP's client_id / client_secret out of a Databricks secret
+       scope. This keeps the SP OAuth material out of the local .env file.
+
+    2. **Direct env vars** (fallback for external readers without a CLI
+       profile): set DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET in .env.
+
+    The returned values are the unwrapped OAuth credentials used for M2M
+    auth against `/oidc/v1/token` — i.e. the same values either way, just
+    sourced differently.
+    """
+    global _SP_CREDS_CACHE
+    if _SP_CREDS_CACHE is not None:
+        return _SP_CREDS_CACHE
+
+    direct_id = os.environ.get("DATABRICKS_CLIENT_ID")
+    direct_secret = os.environ.get("DATABRICKS_CLIENT_SECRET")
+    if direct_id and direct_secret:
+        _SP_CREDS_CACHE = (direct_id, direct_secret)
+        return _SP_CREDS_CACHE
+
+    profile = os.environ.get("DATABRICKS_PROFILE")
+    scope = os.environ.get("SP_SECRET_SCOPE")
+    id_key = os.environ.get("SP_CLIENT_ID_SECRET_KEY")
+    secret_key = os.environ.get("SP_CLIENT_SECRET_SECRET_KEY")
+    if not all([profile, scope, id_key, secret_key]):
+        raise RuntimeError(
+            "Missing service principal credentials. Either set "
+            "DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET directly, or set "
+            "DATABRICKS_PROFILE + SP_SECRET_SCOPE + SP_CLIENT_ID_SECRET_KEY + "
+            "SP_CLIENT_SECRET_SECRET_KEY to fetch them from Databricks secrets."
+        )
+
+    import base64
+    from databricks.sdk import WorkspaceClient
+
+    w = WorkspaceClient(profile=profile)
+    client_id = base64.b64decode(
+        w.secrets.get_secret(scope=scope, key=id_key).value
+    ).decode()
+    client_secret = base64.b64decode(
+        w.secrets.get_secret(scope=scope, key=secret_key).value
+    ).decode()
+    _SP_CREDS_CACHE = (client_id, client_secret)
+    return _SP_CREDS_CACHE
+
+
+def get_oauth_token() -> str:
+    """Fetch a fresh OAuth access token using the service principal's
+    client credentials.
+
+    External Access Beta emphasises M2M OAuth over PATs. For the short-
+    lived demo scripts we fetch a single token at startup; for long-
+    running pipelines (e.g. Flink or Kafka sinks) the engine's UC
+    integration refreshes tokens automatically against the `/oidc/v1/token`
+    endpoint, which is the production path described in the Beta docs.
+    """
+    from databricks.sdk.core import Config, oauth_service_principal
+
+    client_id, client_secret = _resolve_sp_credentials()
+    config = Config(
+        host=DATABRICKS_HOST,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    token_source = oauth_service_principal(config)
+    raw = token_source()
+    # databricks-sdk 0.80+ returns the auth *headers* dict ({"Authorization":
+    # "Bearer <jwt>"}); older versions returned a Token object with an
+    # `access_token` attribute. Support both so _common.py stays portable.
+    if isinstance(raw, dict):
+        auth = raw.get("Authorization", "")
+        if auth.lower().startswith("bearer "):
+            return auth.split(None, 1)[1]
+        raise RuntimeError(f"Unexpected auth header from token source: {raw!r}")
+    return raw.access_token
+
+
+def fq(table: str) -> str:
+    """Fully-qualified table name: catalog.schema.table."""
+    return f"{UC_CATALOG}.{UC_SCHEMA}.{table}"
+
+
+def get_demo_principal() -> str:
+    """Application_id of the service principal that receives demo grants.
+
+    Defaults to the SP we authenticate as (its client_id == application_id),
+    so DEMO_PRINCIPAL doesn't need to be configured separately. Override
+    only if you need to grant to a *different* principal than the one
+    holding the OAuth credentials.
+    """
+    explicit = os.environ.get("DEMO_PRINCIPAL")
+    if explicit:
+        return explicit
+    client_id, _ = _resolve_sp_credentials()
+    return client_id
+
+
+# --- Spark session factory --------------------------------------------------
+# Artifact coordinates follow the convention `io.delta:delta-spark_<scala>:<version>`
+# and `io.unitycatalog:unitycatalog-spark_<scala>:<version>`. Spark version does
+# not appear in the coordinate — Delta 4.x tracks Spark 4.x.
+SCALA_VERSION = os.environ.get("SCALA_VERSION", "2.13")
+DELTA_SPARK_VERSION = os.environ.get("DELTA_SPARK_VERSION", "4.2.0")
+UNITY_CATALOG_SPARK_VERSION = os.environ.get("UC_SPARK_VERSION", "0.4.1")
+HADOOP_AWS_VERSION = os.environ.get("HADOOP_AWS_VERSION", "3.4.2")
+# Extra --packages coordinates (comma-separated) for sites that need more
+# dependencies on the classpath (e.g. Azure ABFS, GCS connectors).
+EXTRA_SPARK_PACKAGES = os.environ.get("EXTRA_SPARK_PACKAGES", "")
+# Optional: override the Ivy/Maven repositories used to resolve --packages.
+# Useful when repo1.maven.org is blocked at the network layer and a mirror
+# (e.g. Artifactory, a local Nexus, or maven-central.storage-download.googleapis.com)
+# is available instead. Comma-separated list.
+SPARK_REPOSITORIES = os.environ.get("SPARK_REPOSITORIES", "")
+
+
+def build_spark(app_name: str = "uc-external-access-demo"):
+    """Create an external Spark session wired to Unity Catalog via catalog commits.
+
+    Version pins (override via env vars if you need to track a different
+    Delta / UC release):
+      - Scala              {SCALA_VERSION}  (default 2.13)
+      - delta-spark        {DELTA_SPARK_VERSION}  (default 4.2.0)
+      - unitycatalog-spark {UNITY_CATALOG_SPARK_VERSION}  (default 0.4.1)
+      - hadoop-aws         {HADOOP_AWS_VERSION}  (default 3.4.0)
+
+    Auth follows the UC Spark connector's OAuth mode — the connector fetches
+    and refreshes its own M2M OAuth tokens against /oidc/v1/token, so no
+    pre-fetched token is baked into the session. This is the production path
+    the External Access Beta recommends for long-running workloads (including
+    Structured Streaming).
+    """
+    from pyspark.sql import SparkSession  # imported lazily so the module is importable without pyspark
+
+    packages = [
+        f"io.delta:delta-spark_{SCALA_VERSION}:{DELTA_SPARK_VERSION}",
+        f"io.unitycatalog:unitycatalog-spark_{SCALA_VERSION}:{UNITY_CATALOG_SPARK_VERSION}",
+        f"org.apache.hadoop:hadoop-aws:{HADOOP_AWS_VERSION}",
+    ]
+    if EXTRA_SPARK_PACKAGES:
+        packages.extend(p.strip() for p in EXTRA_SPARK_PACKAGES.split(",") if p.strip())
+
+    client_id, client_secret = _resolve_sp_credentials()
+    oauth_token_uri = f"{DATABRICKS_HOST}/oidc/v1/token"
+
+    builder = (
+        SparkSession.builder.appName(app_name)
+        .config("spark.jars.packages", ",".join(packages))
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        # Keep the implicit spark_catalog on DeltaCatalog so DataFrameWriter
+        # table resolution doesn't fail when it falls back to spark_catalog
+        # (UCSingleCatalog requires a uri we do not want to set for the
+        # implicit catalog). The explicit UC_CATALOG below is still
+        # the defaultCatalog, so fully-qualified reads/writes go through UC.
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        # UC as an external catalog accessible from Spark
+        .config(
+            f"spark.sql.catalog.{UC_CATALOG}",
+            "io.unitycatalog.spark.UCSingleCatalog",
+        )
+        .config(f"spark.sql.catalog.{UC_CATALOG}.uri", DATABRICKS_HOST)
+        .config(f"spark.sql.catalog.{UC_CATALOG}.auth.type", "oauth")
+        .config(f"spark.sql.catalog.{UC_CATALOG}.auth.oauth.uri", oauth_token_uri)
+        .config(f"spark.sql.catalog.{UC_CATALOG}.auth.oauth.clientId", client_id)
+        .config(f"spark.sql.catalog.{UC_CATALOG}.auth.oauth.clientSecret", client_secret)
+        .config(f"spark.sql.catalog.{UC_CATALOG}.renewCredential.enabled", "true")
+        .config("spark.sql.defaultCatalog", UC_CATALOG)
+        # UC hands back s3:// table URIs; Hadoop 3.4 only ships the s3a://
+        # FileSystem. Route s3:// through S3A so delta-spark can read the
+        # transaction log.
+        .config("spark.hadoop.fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+        .config(
+            "spark.hadoop.fs.AbstractFileSystem.s3.impl",
+            "org.apache.hadoop.fs.s3a.S3A",
+        )
+    )
+    if SPARK_REPOSITORIES:
+        builder = builder.config("spark.jars.repositories", SPARK_REPOSITORIES)
+
+    return builder.getOrCreate()
+
+
+def print_banner(title: str) -> None:
+    bar = "=" * len(title)
+    print(f"\n{bar}\n{title}\n{bar}")
+
+
+# --- DuckDB helper ----------------------------------------------------------
+
+AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
+
+
+def attach_unity_catalog(con) -> None:
+    """Install + load the DuckDB unity_catalog / delta extensions and attach
+    the demo catalog.
+
+    `con` is a duckdb.DuckDBPyConnection. Imported lazily so this module is
+    usable from Spark-only scripts without duckdb installed.
+
+    Requires DuckDB >= 1.5.0 (extension renamed from `uc_catalog`).
+    AWS_REGION must match the region of the S3 bucket that backs the UC
+    metastore. Override via the AWS_REGION env var for other workspaces.
+    """
+    con.execute("INSTALL unity_catalog;")
+    con.execute("LOAD unity_catalog;")
+    con.execute("INSTALL delta;")
+    con.execute("LOAD delta;")
+
+    token = get_oauth_token()
+    # The secret is created without a name so the extension auto-resolves
+    # it by type when ATTACHing without an explicit SECRET reference. The
+    # ENDPOINT is the workspace root URL.
+    con.execute(
+        f"""
+        CREATE SECRET (
+            TYPE UNITY_CATALOG,
+            TOKEN '{token}',
+            ENDPOINT '{DATABRICKS_HOST}/',
+            AWS_REGION '{AWS_REGION}'
+        );
+        """
+    )
+
+    con.execute(
+        f"""
+        ATTACH '{UC_CATALOG}' AS {UC_CATALOG} (
+            TYPE UNITY_CATALOG
+        );
+        """
+    )

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/_common.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/_common.py
@@ -6,8 +6,48 @@ on the operation it is demonstrating.
 """
 from __future__ import annotations
 
+import contextlib
 import os
+import sys
+import tempfile
 from pathlib import Path
+
+
+DEMO_VERBOSE = os.environ.get("DEMO_VERBOSE", "0") == "1"
+
+
+@contextlib.contextmanager
+def _quiet_stderr():
+    """Suppress JVM/Ivy stderr (Spark startup banner, package resolution).
+
+    Replaces fd 2 with a temp file for the duration of the block. On
+    success the captured output is dropped; on exception it is forwarded
+    to the real stderr so genuine errors are not lost. Set DEMO_VERBOSE=1
+    to disable suppression (useful when debugging classpath issues).
+    """
+    if DEMO_VERBOSE:
+        yield
+        return
+    sys.stdout.flush()
+    sys.stderr.flush()
+    saved_fd = os.dup(2)
+    tmp = tempfile.TemporaryFile(mode="w+b")
+    try:
+        os.dup2(tmp.fileno(), 2)
+        try:
+            yield
+        except BaseException:
+            os.dup2(saved_fd, 2)
+            tmp.seek(0)
+            captured = tmp.read()
+            if captured:
+                os.write(2, captured)
+            raise
+        else:
+            os.dup2(saved_fd, 2)
+    finally:
+        os.close(saved_fd)
+        tmp.close()
 
 
 def _load_dotenv() -> None:
@@ -239,12 +279,41 @@ def build_spark(app_name: str = "uc-external-access-demo"):
     if SPARK_REPOSITORIES:
         builder = builder.config("spark.jars.repositories", SPARK_REPOSITORIES)
 
-    return builder.getOrCreate()
+    # Hush log4j during runtime; suppress Ivy resolution + JVM banner during
+    # startup. Override with DEMO_VERBOSE=1 if you need the full noise.
+    builder = builder.config("spark.log.level", "ERROR")
+
+    with _quiet_stderr():
+        spark = builder.getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+    return spark
 
 
 def print_banner(title: str) -> None:
     bar = "=" * len(title)
     print(f"\n{bar}\n{title}\n{bar}")
+
+
+@contextlib.contextmanager
+def script_banner(script_path: str):
+    """Print heavy START/END banners around a standalone script run.
+
+    Suppressed when invoked under run_all.py (which exports
+    ``RUN_ALL_ACTIVE=1`` and prints its own per-step banners) so a single
+    end-to-end run does not double-banner each script.
+    """
+    if os.environ.get("RUN_ALL_ACTIVE") == "1":
+        yield
+        return
+    name = os.path.basename(script_path)
+    bar = "#" * 78
+    print(f"\n{bar}\n#  START  {name}\n{bar}\n", flush=True)
+    try:
+        yield
+        print(f"\n{bar}\n#  END    {name}  —  OK\n{bar}\n", flush=True)
+    except BaseException:
+        print(f"\n{bar}\n#  END    {name}  —  FAILED\n{bar}\n", flush=True)
+        raise
 
 
 # --- DuckDB helper ----------------------------------------------------------
@@ -263,10 +332,11 @@ def attach_unity_catalog(con) -> None:
     AWS_REGION must match the region of the S3 bucket that backs the UC
     metastore. Override via the AWS_REGION env var for other workspaces.
     """
-    con.execute("INSTALL unity_catalog;")
-    con.execute("LOAD unity_catalog;")
-    con.execute("INSTALL delta;")
-    con.execute("LOAD delta;")
+    with _quiet_stderr():
+        con.execute("INSTALL unity_catalog;")
+        con.execute("LOAD unity_catalog;")
+        con.execute("INSTALL delta;")
+        con.execute("LOAD delta;")
 
     token = get_oauth_token()
     # The secret is created without a name so the extension auto-resolves

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/_common.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/_common.py
@@ -181,7 +181,7 @@ def build_spark(app_name: str = "uc-external-access-demo"):
       - Scala              {SCALA_VERSION}  (default 2.13)
       - delta-spark        {DELTA_SPARK_VERSION}  (default 4.2.0)
       - unitycatalog-spark {UNITY_CATALOG_SPARK_VERSION}  (default 0.4.1)
-      - hadoop-aws         {HADOOP_AWS_VERSION}  (default 3.4.0)
+      - hadoop-aws         {HADOOP_AWS_VERSION}  (default 3.4.2)
 
     Auth follows the UC Spark connector's OAuth mode — the connector fetches
     and refreshes its own M2M OAuth tokens against /oidc/v1/token, so no

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/requirements.txt
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/requirements.txt
@@ -1,0 +1,11 @@
+# Pinned to the Delta Lake 4.2 release versions.
+# - Apache Spark 4.1
+# - Delta Spark 4.2.0
+# - unitycatalog-spark 0.4.1 (pulled by Spark via --packages, not pip)
+# - DuckDB 1.5.2 with the unity_catalog + delta core extensions
+#   (see https://duckdb.org/docs/current/core_extensions/unity_catalog).
+pyspark==4.1.1
+delta-spark==4.2.0
+duckdb==1.5.2
+pandas>=2.2.0
+databricks-sdk>=0.30.0

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_all.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_all.py
@@ -5,13 +5,25 @@ Python demo script in order. Safe to run repeatedly — each pass converges
 on the same final state.
 
 Sequence:
-  1. run_setup.py              (DROP + CREATE catalog, seed TPCH, grants)
+  1. run_setup.py              (DROP + CREATE catalog, seed TPCH, grants)   v0
   2. 01_spark_external_read.py (external Spark batch read)
-  3. 02_spark_external_write.py (external Spark APPEND + CTAS)
+  3. 02_spark_external_write.py (external Spark APPEND + CTAS)              v1
   4. 03_spark_streaming.py     (external Spark Structured Streaming append)
   5. 04_duckdb_read.py         (DuckDB SELECT + time travel)
-  6. 05_duckdb_insert.py       (DuckDB INSERT)
-  7. 06_verify_cross_engine.py (cross-engine DESCRIBE HISTORY verify)
+  6. 05_duckdb_insert.py       (DuckDB INSERT VALUES + INSERT SELECT)       v2, v3
+  7. 02_spark_external_write.py (re-run: DELETE markers + APPEND fresh ones) v4, v5
+  8. 06_verify_cross_engine.py (cross-engine DESCRIBE HISTORY verify)
+  9. run_cleanup.py            (DROP catalog + schema)
+
+The second pass of 02_spark_external_write.py is intentional — it adds a
+DELETE commit (v4, removing the markers from the first pass) and a fresh
+APPEND commit (v5), giving the final `orders` history a 6-row mix of
+Databricks-Runtime + DuckDB + external Spark engines, which is the
+attribution story the blog screenshots.
+
+The cleanup step at the end returns the workspace to its pre-demo state.
+Skip it with `SKIP_SCRIPTS=cleanup python run_all.py` if you want to
+poke at the demo tables in the SQL editor afterwards.
 
 Environment:
   SKIP_SCRIPTS   comma-separated stage names to skip.
@@ -30,13 +42,15 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 
 # (friendly-name, script-file-or-None-if-inline, extra-args)
 STEPS: list[tuple[str, str]] = [
-    ("setup",         "run_setup.py"),
-    ("spark_read",    "01_spark_external_read.py"),
-    ("spark_write",   "02_spark_external_write.py"),
-    ("streaming",     "03_spark_streaming.py"),
-    ("duckdb_read",   "04_duckdb_read.py"),
-    ("duckdb_insert", "05_duckdb_insert.py"),
-    ("verify",        "06_verify_cross_engine.py"),
+    ("setup",            "run_setup.py"),
+    ("spark_read",       "01_spark_external_read.py"),
+    ("spark_write",      "02_spark_external_write.py"),
+    ("streaming",        "03_spark_streaming.py"),
+    ("duckdb_read",      "04_duckdb_read.py"),
+    ("duckdb_insert",    "05_duckdb_insert.py"),
+    ("spark_write_redo", "02_spark_external_write.py"),
+    ("verify",           "06_verify_cross_engine.py"),
+    ("cleanup",          "run_cleanup.py"),
 ]
 
 
@@ -53,29 +67,36 @@ def main() -> int:
         print(f"Skip:   {sorted(skip)}")
     print()
 
+    bar = "#" * 78
+
     failed: list[str] = []
-    for name, script in STEPS:
-        banner = f"===== [{name}] {script} ====="
+    for idx, (name, script) in enumerate(STEPS, start=1):
         if name in skip or script in skip:
-            print(f"{banner}  (skipped)\n")
+            print(f"\n{bar}\n#  SKIP   step {idx}/{len(STEPS)}  [{name}]  {script}\n{bar}\n")
             continue
-        print(banner)
+        print(f"\n{bar}\n#  START  step {idx}/{len(STEPS)}  [{name}]  {script}\n{bar}\n")
         start = time.time()
-        rc = subprocess.call([python, script], cwd=SCRIPTS_DIR)
+        # RUN_ALL_ACTIVE tells _common.script_banner() to suppress the
+        # in-script START/END banner so the runner's banner is the only
+        # one that prints (no double-banners during end-to-end runs).
+        env = {**os.environ, "RUN_ALL_ACTIVE": "1"}
+        rc = subprocess.call([python, script], cwd=SCRIPTS_DIR, env=env)
         dur = time.time() - start
         status = "OK" if rc == 0 else f"FAILED (rc={rc})"
-        print(f"----- [{name}] {status} in {dur:.1f}s\n")
+        print(f"\n{bar}\n#  END    step {idx}/{len(STEPS)}  [{name}]  {script}  —  {status} in {dur:.1f}s\n{bar}\n")
         if rc != 0:
             failed.append(name)
             # Stop at first failure — downstream steps depend on setup / writes.
             break
 
     total = time.time() - total_start
-    print("=" * 60)
+    print(bar)
     if failed:
-        print(f"FAIL: {', '.join(failed)}  (total {total:.1f}s)")
+        print(f"#  FAIL: {', '.join(failed)}  (total {total:.1f}s)")
+        print(bar)
         return 1
-    print(f"All steps completed in {total:.1f}s")
+    print(f"#  All {len(STEPS)} steps completed in {total:.1f}s")
+    print(bar)
     return 0
 
 

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_all.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_all.py
@@ -1,0 +1,83 @@
+"""End-to-end idempotent runner for the External Access demo.
+
+Wipes the demo catalog, reseeds it from `samples.tpch`, then runs every
+Python demo script in order. Safe to run repeatedly — each pass converges
+on the same final state.
+
+Sequence:
+  1. run_setup.py              (DROP + CREATE catalog, seed TPCH, grants)
+  2. 01_spark_external_read.py (external Spark batch read)
+  3. 02_spark_external_write.py (external Spark APPEND + CTAS)
+  4. 03_spark_streaming.py     (external Spark Structured Streaming append)
+  5. 04_duckdb_read.py         (DuckDB SELECT + time travel)
+  6. 05_duckdb_insert.py       (DuckDB INSERT)
+  7. 06_verify_cross_engine.py (cross-engine DESCRIBE HISTORY verify)
+
+Environment:
+  SKIP_SCRIPTS   comma-separated stage names to skip.
+                 Example: SKIP_SCRIPTS=streaming,verify python run_all.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+
+# (friendly-name, script-file-or-None-if-inline, extra-args)
+STEPS: list[tuple[str, str]] = [
+    ("setup",         "run_setup.py"),
+    ("spark_read",    "01_spark_external_read.py"),
+    ("spark_write",   "02_spark_external_write.py"),
+    ("streaming",     "03_spark_streaming.py"),
+    ("duckdb_read",   "04_duckdb_read.py"),
+    ("duckdb_insert", "05_duckdb_insert.py"),
+    ("verify",        "06_verify_cross_engine.py"),
+]
+
+
+def main() -> int:
+    skip_raw = os.environ.get("SKIP_SCRIPTS", "").strip().lower()
+    skip = {s.strip() for s in skip_raw.split(",") if s.strip()}
+
+    python = sys.executable
+    total_start = time.time()
+
+    print(f"Runner: {python}")
+    print(f"Cwd:    {SCRIPTS_DIR}")
+    if skip:
+        print(f"Skip:   {sorted(skip)}")
+    print()
+
+    failed: list[str] = []
+    for name, script in STEPS:
+        banner = f"===== [{name}] {script} ====="
+        if name in skip or script in skip:
+            print(f"{banner}  (skipped)\n")
+            continue
+        print(banner)
+        start = time.time()
+        rc = subprocess.call([python, script], cwd=SCRIPTS_DIR)
+        dur = time.time() - start
+        status = "OK" if rc == 0 else f"FAILED (rc={rc})"
+        print(f"----- [{name}] {status} in {dur:.1f}s\n")
+        if rc != 0:
+            failed.append(name)
+            # Stop at first failure — downstream steps depend on setup / writes.
+            break
+
+    total = time.time() - total_start
+    print("=" * 60)
+    if failed:
+        print(f"FAIL: {', '.join(failed)}  (total {total:.1f}s)")
+        return 1
+    print(f"All steps completed in {total:.1f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_cleanup.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_cleanup.py
@@ -1,0 +1,85 @@
+"""Execute 99_cleanup.sql against a Databricks SQL warehouse.
+
+Drops the catalog + schema created by run_setup.py so the workspace is
+returned to its pre-demo state. Uses the same admin-level
+DATABRICKS_PROFILE / DATABRICKS_WAREHOUSE_ID as run_setup.py.
+
+Substitutions applied:
+  uc_ext_access_demo  -> UC_CATALOG (when overridden)
+  tpch_managed        -> UC_SCHEMA  (when overridden)
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import _common  # noqa: F401  -- loads .env
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import StatementState
+
+
+DEFAULT_CATALOG = "uc_ext_access_demo"
+DEFAULT_SCHEMA = "tpch_managed"
+
+
+def _strip_comments(sql: str) -> str:
+    return "\n".join(
+        line for line in sql.splitlines() if not line.lstrip().startswith("--")
+    )
+
+
+def _split_statements(sql: str) -> list[str]:
+    parts = [p.strip() for p in sql.split(";")]
+    return [p for p in parts if p]
+
+
+def main() -> int:
+    profile = _common.require("DATABRICKS_PROFILE")
+    warehouse_id = _common.require("DATABRICKS_WAREHOUSE_ID")
+    uc_catalog = _common.UC_CATALOG
+    uc_schema = _common.UC_SCHEMA
+
+    sql_path = Path(__file__).with_name("99_cleanup.sql")
+    raw = sql_path.read_text()
+
+    if uc_catalog != DEFAULT_CATALOG:
+        raw = raw.replace(DEFAULT_CATALOG, uc_catalog)
+    if uc_schema != DEFAULT_SCHEMA:
+        raw = re.sub(rf"\b{re.escape(DEFAULT_SCHEMA)}\b", uc_schema, raw)
+
+    stmts = _split_statements(_strip_comments(raw))
+
+    w = WorkspaceClient(profile=profile)
+    print(f"Profile:      {profile}")
+    print(f"Warehouse:    {warehouse_id}")
+    print(f"Catalog:      {uc_catalog}")
+    print(f"Schema:       {uc_schema}")
+    print(f"Statements:   {len(stmts)}")
+    print()
+
+    # All cleanup statements operate at the catalog level (DROP CATALOG /
+    # DROP SCHEMA), so they must run without an active catalog/schema
+    # context — the catalog is about to disappear.
+    for idx, stmt in enumerate(stmts, 1):
+        first_line = stmt.splitlines()[0][:90]
+        print(f"[{idx}/{len(stmts)}] {first_line}")
+        resp = w.statement_execution.execute_statement(
+            warehouse_id=warehouse_id,
+            statement=stmt,
+            wait_timeout="50s",
+        )
+        state = resp.status.state if resp.status else None
+        if state == StatementState.SUCCEEDED:
+            print("    OK")
+        else:
+            msg = resp.status.error.message if resp.status and resp.status.error else "no details"
+            print(f"    FAILED state={state}: {msg}")
+            return 1
+    print("\nCleanup complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    with _common.script_banner(__file__):
+        sys.exit(main())

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_setup.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_setup.py
@@ -1,0 +1,108 @@
+"""Execute 00_setup_databricks.sql against a Databricks SQL warehouse.
+
+Uses the admin-level DATABRICKS_PROFILE from .env (not the demo service
+principal — the SP usually lacks CREATE CATALOG). All values come from
+environment variables so the setup runs in any workspace:
+
+  DATABRICKS_PROFILE        CLI profile used for auth
+  DATABRICKS_WAREHOUSE_ID   Serverless SQL warehouse id
+  UC_CATALOG, UC_SCHEMA     Target catalog + schema names
+  DEMO_PRINCIPAL            Application_id of the SP that receives grants
+
+Substitutions applied to the SQL text before execution:
+  <DEMO_PRINCIPAL>    -> DEMO_PRINCIPAL
+  uc_ext_access_demo  -> UC_CATALOG   (only when different from default)
+  tpch_managed        -> UC_SCHEMA    (only when different from default)
+
+`USE CATALOG` / `USE SCHEMA` are stripped because the Statement Execution
+API is stateless; catalog + schema are passed per-statement instead.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import _common  # noqa: F401  -- loads .env
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import StatementState
+
+
+DEFAULT_CATALOG = "uc_ext_access_demo"
+DEFAULT_SCHEMA = "tpch_managed"
+
+
+def _strip_comments(sql: str) -> str:
+    # Remove -- line comments; keep the rest intact.
+    return "\n".join(
+        line for line in sql.splitlines() if not line.lstrip().startswith("--")
+    )
+
+
+def _split_statements(sql: str) -> list[str]:
+    # Naive but fine for this file — no semicolons inside string literals.
+    parts = [p.strip() for p in sql.split(";")]
+    return [p for p in parts if p]
+
+
+def main() -> int:
+    profile = _common.require("DATABRICKS_PROFILE")
+    warehouse_id = _common.require("DATABRICKS_WAREHOUSE_ID")
+    # DEMO_PRINCIPAL defaults to the SP we authenticate as (its client_id);
+    # override only if you need to grant to a different principal.
+    demo_principal = _common.get_demo_principal()
+    uc_catalog = _common.UC_CATALOG
+    uc_schema = _common.UC_SCHEMA
+
+    sql_path = Path(__file__).with_name("00_setup_databricks.sql")
+    raw = sql_path.read_text()
+
+    raw = raw.replace("<DEMO_PRINCIPAL>", demo_principal)
+    if uc_catalog != DEFAULT_CATALOG:
+        raw = raw.replace(DEFAULT_CATALOG, uc_catalog)
+    if uc_schema != DEFAULT_SCHEMA:
+        # Guard against accidental substring matches by requiring a word break.
+        raw = re.sub(rf"\b{re.escape(DEFAULT_SCHEMA)}\b", uc_schema, raw)
+
+    stmts = _split_statements(_strip_comments(raw))
+    # Drop USE CATALOG / USE SCHEMA — the API doesn't persist session state.
+    stmts = [s for s in stmts if not re.match(r"^USE\s+(CATALOG|SCHEMA)\b", s, re.I)]
+
+    w = WorkspaceClient(profile=profile)
+    print(f"Profile:      {profile}")
+    print(f"Warehouse:    {warehouse_id}")
+    print(f"Catalog:      {uc_catalog}")
+    print(f"Schema:       {uc_schema}")
+    print(f"Grantee SP:   {demo_principal}")
+    print(f"Statements:   {len(stmts)}")
+    print()
+
+    # Statements that must run without a catalog/schema context — either the
+    # catalog doesn't exist yet (CREATE) or we're about to destroy it (DROP).
+    catalog_free = re.compile(r"^\s*(DROP\s+CATALOG|CREATE\s+CATALOG)\b", re.I)
+
+    for idx, stmt in enumerate(stmts, 1):
+        first_line = stmt.splitlines()[0][:90]
+        print(f"[{idx}/{len(stmts)}] {first_line}")
+        kwargs = {"warehouse_id": warehouse_id, "statement": stmt, "wait_timeout": "50s"}
+        if not catalog_free.match(stmt):
+            kwargs["catalog"] = uc_catalog
+            kwargs["schema"] = uc_schema
+        resp = w.statement_execution.execute_statement(**kwargs)
+        state = resp.status.state if resp.status else None
+        if state == StatementState.SUCCEEDED:
+            if resp.result and resp.result.data_array:
+                for row in resp.result.data_array[:10]:
+                    print("   ", row)
+            print("    OK")
+        else:
+            msg = resp.status.error.message if resp.status and resp.status.error else "no details"
+            print(f"    FAILED state={state}: {msg}")
+            return 1
+    print("\nSetup complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_setup.py
+++ b/2026-05-external-access-to-unity-catalog-managed-delta-tables/run_setup.py
@@ -105,4 +105,5 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    with _common.script_banner(__file__):
+        sys.exit(main())

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,3 +33,4 @@
 /2026-02-platform-observability-dashboard @sashankkotta-db @pathak-rutuja
 /2026-02-realtime-streaming-fraud-feature-engineering-with-lakebase/*  @jpdatabricks
 /2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs/* @dipankarkush-db
+/2026-05-external-access-to-unity-catalog-managed-delta-tables/* @dipankarkush-db


### PR DESCRIPTION
## Summary

Adds the runnable companion code for the **External Access to Unity Catalog Managed Delta Tables (Beta)** community blog under a new `2026-05-external-access-to-unity-catalog-managed-delta-tables/` folder, following the existing `YYYY-MM-<slug>/` convention.

The pipeline shows catalog-managed Delta commits working end-to-end from outside Databricks across multiple external engines:

- **External Apache Spark** (Spark 4.1.1 + Delta 4.2.0 + UC connector 0.4.1) — batch read, APPEND, CTAS, and Structured Streaming.
- **DuckDB 1.5.2** with the `unity_catalog` + `delta` core extensions — SELECT, JOIN, INSERT.

Every commit produced by an external engine is coordinated by Unity Catalog, so writers don't step on each other and readers see a single, consistent transaction log no matter which engine wrote the rows. Cross-engine consistency is shown by `DESCRIBE HISTORY`, where every commit is attributed to the engine that produced it (Databricks Runtime, external Spark, or DuckDB).

## What's in the folder

- `00_setup_databricks.sql` + `99_cleanup.sql` — DDL applied via the Databricks SQL Statement Execution API (catalog + schema + 8 TPCH clones + grants).
- `_common.py` — shared OAuth + Spark/DuckDB session builders. All version pins overridable via env vars.
- `01_spark_external_read.py` … `06_verify_cross_engine.py` — one demo per operation.
- `run_setup.py`, `run_cleanup.py`, `run_all.py` — drivers. `run_all.py` is fully idempotent and runs a 9-step pipeline (setup → spark_read → spark_write → streaming → duckdb_read → duckdb_insert → spark_write_redo → verify → cleanup) so end-to-end runs always converge on the same 6-row mixed-engine `orders` history (v0 Databricks CTAS → v1 external Spark APPEND → v2/v3 DuckDB INSERTs → v4 external Spark DELETE → v5 external Spark APPEND).
- `README.md` — run guide, prerequisites, version pin table, troubleshooting.
- `CODEOWNERS` — adds `/2026-05-external-access-to-unity-catalog-managed-delta-tables/* @dipankarkush-db`.

## Notable design decisions

- Catalog-managed table feature is set explicitly on every external CTAS / CREATE: `USING DELTA TBLPROPERTIES ('delta.feature.catalogManaged' = 'supported')`.
- UC connector is in OAuth mode (`auth.type=oauth`, `auth.oauth.uri=$HOST/oidc/v1/token`, `renewCredential.enabled=true`) so the connector mints + refreshes its own M2M tokens — no pre-fetched bearer baked into the session.
- `s3://` URIs from UC are routed through the S3A FileSystem since Hadoop 3.4 only ships `s3a://`.
- DuckDB extension is `unity_catalog` (the renamed-in-1.5.x successor to `uc_catalog`); attach uses an anonymous `CREATE SECRET (TYPE UNITY_CATALOG, ...)` with workspace-root `ENDPOINT`.
- M2M OAuth only — no PATs anywhere.
- No real workspace URLs, SP credentials, or warehouse IDs in any tracked file. `.env` is gitignored; `.env.example` is the public template.

## Test plan

- [x] `python run_all.py` end-to-end against a preview-enrolled Databricks workspace produces v0–v5 in `orders` with the expected mix of `engineInfo` values
- [x] Each script runs cleanly when invoked individually (idempotent re-runs)
- [x] DESCRIBE HISTORY output fits one terminal row per commit (no wrap) — JVM/Ivy noise suppressed by default; `DEMO_VERBOSE=1` re-enables for debugging
- [x] `SKIP_SCRIPTS=cleanup python run_all.py` leaves the catalog in place for inspection
- [x] No real workspace URLs / SP credentials / warehouse IDs in any tracked file

This pull request and its description were written by Isaac.