### PR TITLE
Add unitycatalog to core dependencies for Blog - 2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs

### DIFF
--- a/2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs/requirements/base.txt
+++ b/2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs/requirements/base.txt
@@ -1,3 +1,4 @@
 # Core dependencies (required by all scripts)
 databricks-sdk
 python-dotenv
+unitycatalog


### PR DESCRIPTION
While following the documentation for the blog article - `2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs` , I encountered following error

```
 python run_download_and_process.py
============================================================
STEP 1: Download images from Unity Catalog (Daft)
============================================================
Traceback (most recent call last):
  File "/Users/kchandan/workspace/databricks-blogposts/2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs/query_engines/daft_download.py", line 17, in <module>
    from daft.unity_catalog import UnityCatalog
  File "/Users/kchandan/workspace/venv/lib/python3.9/site-packages/daft/unity_catalog/__init__.py", line 3, in <module>
    from .unity_catalog import UnityCatalog, UnityCatalogTable  # noqa: TID253
  File "/Users/kchandan/workspace/venv/lib/python3.9/site-packages/daft/unity_catalog/unity_catalog.py", line 8, in <module>
    import unitycatalog
ModuleNotFoundError: No module named 'unitycatalog'

Download failed with exit code 1
```
After installing the unitycatalog Python repo, issue was fixed


