### PR TITLE
Add unitycatalog to base requirements for 2026-04 UC Volumes blog

### DIFF
--- a/2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs/README.md
+++ b/2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs/README.md
@@ -41,7 +41,7 @@ Authenticates to Databricks using OAuth U2M (via the Databricks SDK), then downl
 ├── processing/                         # Downstream ML inference
 │   └── huggingface_inference.py
 ├── requirements/                       # Split by engine/use case
-│   ├── base.txt                        # databricks-sdk, python-dotenv
+│   ├── base.txt                        # databricks-sdk, python-dotenv, unitycatalog
 │   ├── daft.txt
 │   ├── duckdb.txt
 │   ├── ray.txt

--- a/2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs/requirements/base.txt
+++ b/2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs/requirements/base.txt
@@ -3,3 +3,4 @@
 # vending API (w.temporary_volume_credentials.generate_temporary_volume_credentials).
 databricks-sdk>=0.108.0
 python-dotenv
+unitycatalog


### PR DESCRIPTION
## Summary
- Adds `unitycatalog` to `2026-04-processing-unstructured-data-in-volumes-with-UC-open-APIs/requirements/base.txt`
- Daft's `from daft.unity_catalog import UnityCatalog` (used in `query_engines/daft_download.py`) transitively imports the `unitycatalog` package, which is not pulled in by `daft`/`getdaft`. Without it, users following the blog hit `ModuleNotFoundError: No module named 'unitycatalog'` on the first download step.
- Also updates the project-structure comment in `README.md` to reflect the new dep.
- Same fix proposed in #83 (still open) — this is a follow-up to the freshly-merged #87.

## Test plan
- [x] `pip install -r requirements/daft.txt` resolves `unitycatalog` from PyPI
- [x] `python query_engines/daft_download.py` no longer raises `ModuleNotFoundError: No module named 'unitycatalog'`

This pull request and its description were written by Isaac.