### PR TITLE
Add 2026-07 SDP ForEachBatch sink blog code

### DIFF
--- a/2026-07-sdp-foreachbatch-sink/01_contact_cleanup_sink.py
+++ b/2026-07-sdp-foreachbatch-sink/01_contact_cleanup_sink.py
@@ -1,0 +1,45 @@
+# Contact cleanup: one micro-batch, two idempotent Delta writes.
+#
+# Phone numbers are normalized to E.164 with the phonenumbers library. Rows
+# that parse cleanly land in a curated table; the rest go to a quarantine
+# table for review. Both appends are idempotent: they key txnVersion on the
+# ForEachBatch batch_id, so a retried batch is skipped as an already-seen
+# duplicate rather than double-written.
+#
+# Companion code for the Databricks Community blog post
+# "One Pipeline, Any Destination: The ForEachBatch Sink in Spark Declarative
+# Pipelines is now GA".
+
+import phonenumbers
+
+from pyspark import pipelines as dp
+from pyspark.sql import functions as F
+
+
+@F.udf("string")
+def to_e164(raw):
+    if not raw:
+        return None
+    try:
+        parsed = phonenumbers.parse(raw, "US")
+        return phonenumbers.format_number(
+            parsed, phonenumbers.PhoneNumberFormat.E164)
+    except phonenumbers.NumberParseException:
+        return None
+
+
+@dp.foreach_batch_sink(name="contact_cleanup_sink")
+def clean_contacts(df, batch_id):
+    cleaned = df.withColumn("phone_e164", to_e164("phone_raw")).persist()
+    (cleaned.where("phone_e164 IS NOT NULL").write
+        .option("txnVersion", batch_id).option("txnAppId", "contact_cleanup_clean")
+        .mode("append").saveAsTable("main.crm.contacts_clean"))
+    (cleaned.where("phone_e164 IS NULL").write
+        .option("txnVersion", batch_id).option("txnAppId", "contact_cleanup_quarantine")
+        .mode("append").saveAsTable("main.crm.contacts_quarantine"))
+    cleaned.unpersist()
+
+
+@dp.append_flow(target="contact_cleanup_sink")
+def raw_contacts_flow():
+    return spark.readStream.table("main.crm.raw_contacts")

--- a/2026-07-sdp-foreachbatch-sink/02_latency_watchdog_sink.py
+++ b/2026-07-sdp-foreachbatch-sink/02_latency_watchdog_sink.py
@@ -1,0 +1,61 @@
+# Latency watchdog: a ForEachBatch sink that turns a streaming pipeline into
+# its own freshness monitor.
+#
+# Each micro-batch computes per-cluster ingestion and event lag percentiles in
+# a single groupBy().agg() and POSTs them to an observability platform over
+# REST. Failures inside the sink are caught and logged so a hiccup in the
+# observability stack can never break primary ingestion.
+#
+# Companion code for the Databricks Community blog post
+# "One Pipeline, Any Destination: The ForEachBatch Sink in Spark Declarative
+# Pipelines is now GA".
+
+import requests
+
+from pyspark import pipelines as dp
+from pyspark.sql import functions as F
+
+METRICS_ENDPOINT = "https://observability.example.com/api/v1/metrics"
+# Read once at definition time. dbutils is not available inside the sink body.
+API_TOKEN = dbutils.secrets.get(scope="observability", key="api_token")
+
+
+def post_latency_metrics(rows, batch_id):
+    payload = [{**row.asDict(), "batch_id": batch_id} for row in rows]
+    requests.post(
+        METRICS_ENDPOINT, json=payload, timeout=10,
+        headers={"Authorization": f"Bearer {API_TOKEN}"},
+    ).raise_for_status()
+
+
+@dp.foreach_batch_sink(name="security_events_latency_metrics_sink")
+def emit_latency_metrics(batch_df, batch_id):
+    try:
+        if batch_df.isEmpty():
+            return
+        now_s = F.unix_timestamp(F.current_timestamp())
+        pcts = F.array(F.lit(0.01), F.lit(0.5), F.lit(0.9), F.lit(0.99))
+        latency_df = (
+            batch_df
+            .withColumn("ingestion_lag_s", now_s - F.unix_timestamp(F.col("etl_ingestion_timestamp")))
+            .withColumn("event_lag_s", now_s - F.unix_timestamp(F.col("_event_timestamp")))
+        )
+        rows = (
+            latency_df.where(F.col("cluster_name").isNotNull())
+            .groupBy("cluster_name")
+            .agg(
+                F.percentile_approx("ingestion_lag_s", pcts).alias("ingestion_lag_p"),
+                F.percentile_approx("event_lag_s", pcts).alias("event_lag_p"),
+            )
+            .collect()
+        )
+        post_latency_metrics(rows, batch_id)
+    except Exception as e:
+        # Observability must never break primary ingestion.
+        print(f"[latency-metrics] batch {batch_id} failed: {e}")
+
+
+@dp.append_flow(target="security_events_latency_metrics_sink")
+def latency_metrics_flow():
+    return (spark.readStream.table("security_events_final")
+            .select("cluster_name", "etl_ingestion_timestamp", "_event_timestamp"))

--- a/2026-07-sdp-foreachbatch-sink/README.md
+++ b/2026-07-sdp-foreachbatch-sink/README.md
@@ -1,0 +1,43 @@
+# One Pipeline, Any Destination: The ForEachBatch Sink in Spark Declarative Pipelines
+
+Companion code for the Databricks Community technical blog post
+**"One Pipeline, Any Destination: The ForEachBatch Sink in Spark Declarative Pipelines is now GA"**
+(blog link added once published).
+
+## Overview
+
+The ForEachBatch sink lets a Spark Declarative Pipeline (SDP) write streaming
+data to any destination from inside a single managed pipeline: REST endpoints,
+search and vector indexes, multiple Delta tables, and multi-topic Kafka routing.
+This folder holds the two runnable examples from the post.
+
+## Contents
+
+| File | What it shows |
+| --- | --- |
+| `01_contact_cleanup_sink.py` | One micro-batch, two idempotent Delta writes. Phone numbers are normalized to E.164 with the `phonenumbers` library; rows that parse cleanly land in a curated table, the rest in a quarantine table. Idempotency uses `txnVersion`/`txnAppId` keyed on `batch_id`. |
+| `02_latency_watchdog_sink.py` | A latency watchdog built on the same pipeline that produces the data. Adapted from a security team at a large AI lab: each micro-batch computes per-cluster ingestion and event lag percentiles in one `groupBy().agg()` and POSTs them to an observability platform over REST. Sink failures are caught and logged so observability can never break primary ingestion. |
+
+## Requirements
+
+- A Databricks workspace with Spark Declarative Pipelines (serverless recommended).
+- Python packages, installed through the pipeline environment: `phonenumbers`, `requests`.
+- `01_contact_cleanup_sink.py` expects a source Streaming Table `main.crm.raw_contacts`.
+- `02_latency_watchdog_sink.py` expects a source table `security_events_final` and an
+  `observability` secret scope with an `api_token` key. Swap the endpoint and table
+  names for your own.
+
+## Data
+
+No datasets are included. Both examples read from tables you provide; generate small
+sample data with Faker or a synthetic generator if you want to run them end to end.
+
+## Licenses
+
+- Databricks License — see the repository `LICENSE` (unchanged).
+- `phonenumbers` — Apache License 2.0.
+- `requests` — Apache License 2.0.
+
+## Authors
+
+John Armstrong (john.armstrong@databricks.com)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,3 +40,4 @@
 /2026-05-ai-functions-data-warehouse-use-cases/* @ismailmakhlouf-dbx @srikantdas11
 /2026-05-coding-agent-sandboxes/* @jlieow
 /2026-06-rtm-on-sdp-flight-tracker/* @apingledbx
+/2026-07-sdp-foreachbatch-sink/* @jarmstrongdbrx


### PR DESCRIPTION
Companion code for the Databricks Community blog post "One Pipeline, Any Destination: The ForEachBatch Sink in Spark Declarative Pipelines is now GA."

New folder `2026-07-sdp-foreachbatch-sink/` with two runnable examples:
- `01_contact_cleanup_sink.py` — one-pass fan-out to a clean table and a quarantine table with idempotent Delta writes.
- `02_latency_watchdog_sink.py` — per-cluster latency percentiles POSTed to an observability platform from inside the pipeline.

I have read the contribution guidelines.

Checklist:
- [x] No sensitive information, no PII, no bundled datasets.
- [x] `README.md` added with content overview, requirements, and license list.
- [x] Author added to `CODEOWNERS` (`/2026-07-sdp-foreachbatch-sink/* @jarmstrongdbrx`).
- [x] Databricks LICENSE unchanged.
- [x] SME approval comment on this PR (pending).

Blog link will be added to the README once the post is live.
